### PR TITLE
if a createNode fails - delete it's leftovers from the api as well

### DIFF
--- a/src/app/editor/components/multi-file-upload-dialog/multi-file-upload-dialog.component.html
+++ b/src/app/editor/components/multi-file-upload-dialog/multi-file-upload-dialog.component.html
@@ -40,6 +40,7 @@
                 <div
                     *ngFor="let fileWithBlob of filesWithBlobs"
                     class="media-box"
+                    [class.error]="fileWithBlob.progress === 'error'"
                 >
                     <icon *ngIf="!isSaving" class="button-close" (click)="onFileRemoved(fileWithBlob)">close</icon>
 

--- a/src/app/editor/components/multi-file-upload-dialog/multi-file-upload-dialog.component.scss
+++ b/src/app/editor/components/multi-file-upload-dialog/multi-file-upload-dialog.component.scss
@@ -20,6 +20,10 @@
         margin-right: 0;
     }
 
+    &.error {
+        border: 1px solid $gtx-color-alert;
+    }
+
     .button-close {
         display: none;
         position: absolute;

--- a/src/app/editor/components/multi-file-upload-dialog/multi-file-upload-dialog.component.scss
+++ b/src/app/editor/components/multi-file-upload-dialog/multi-file-upload-dialog.component.scss
@@ -7,7 +7,7 @@
 }
 
 .media-box {
-    width: 32%;
+    width: 24%;
     margin-right: 1%;
     height: 300px;
     border: 1px solid $gtx-color-primary;
@@ -16,7 +16,7 @@
     box-sizing: border-box;
     position: relative;
 
-    &:nth-of-type(3n) {
+    &:nth-of-type(4n) {
         margin-right: 0;
     }
 
@@ -49,7 +49,7 @@
     }
 
     .node-icon {
-        font-size: 20vw;
+        font-size: 10vw;
         width: 100%;
         text-align: center;
     }
@@ -97,6 +97,29 @@
         .button-close {
             display: block;
             animation: fadeIn 0.3s;
+        }
+    }
+
+
+    @media screen and (max-width: $medium-screen) {
+        width: 32%;
+        &:nth-of-type(3n) {
+            margin-right: 0;
+        }
+
+        .node-icon {
+            font-size: 20vw;
+        }
+    }
+
+    @media screen and (max-width: $small-screen) {
+        width: 49%;
+        &:nth-of-type(2n) {
+            margin-right: 0;
+        }
+
+        .node-icon {
+            font-size: 20vw;
         }
     }
 }

--- a/src/app/editor/components/multi-file-upload-dialog/multi-file-upload-dialog.component.ts
+++ b/src/app/editor/components/multi-file-upload-dialog/multi-file-upload-dialog.component.ts
@@ -21,7 +21,7 @@ import { EntitiesService } from '../../../state/providers/entities.service';
 interface FileWithBlob {
     file: BinaryField;
     blob: SafeUrl;
-    progress: 'none' | 'uploading' | 'done';
+    progress: 'none' | 'uploading' | 'done' | 'error';
     mediaType: string;
 }
 @Component({
@@ -111,6 +111,9 @@ export class MultiFileUploadDialogComponent implements IModalDialog, OnInit {
                 .then(response => {
                     fileWithBlobs.progress = 'done';
                     return response;
+                }).catch(error => {
+                    fileWithBlobs.progress = 'error';
+                    throw error;
                 });
         });
 
@@ -118,7 +121,10 @@ export class MultiFileUploadDialogComponent implements IModalDialog, OnInit {
             this.listEffects.loadChildren(this.project, this.parentUuid, this.language);
             this.closeFn(true);
         }).catch(error => {
-            console.log('Failed with error', error);
+            // Remove the uploaded files. The failed ones will have an indicator displayed.
+            this.filesWithBlobs = this.filesWithBlobs.filter(fileWitBlob => fileWitBlob.progress !== 'done');
+            this.isSaving = false;
+            this.listEffects.loadChildren(this.project, this.parentUuid, this.language);
         });
     }
 

--- a/src/app/editor/components/node-editor/node-editor.component.ts
+++ b/src/app/editor/components/node-editor/node-editor.component.ts
@@ -199,6 +199,7 @@ export class NodeEditorComponent implements OnInit, OnDestroy {
                         }
                     }, error => {
                         this.isSaving = false;
+                        this.changeDetector.detectChanges();
                     });
             } else {
                 saveFn = this.editorEffects.saveNode(this.node, this.tagsBar.isDirty ? this.tagsBar.nodeTags : null)

--- a/src/app/editor/providers/editor-effects.service.ts
+++ b/src/app/editor/providers/editor-effects.service.ts
@@ -81,10 +81,9 @@ export class EditorEffectsService {
                     message: 'editor.node_save_error'
                 });
 
-                /**
-                 * For the new nodes, if something got wrong while saving - delete the node immediatly.
-                 * That way the editor will decide what to do next (stay in an unchanged state?),
-                 */
+
+                // For the new nodes, if something went wrong while saving - delete the node immediately.
+                // That way the editor will decide what to do next (stay in an unchanged state?),
                 this.api.project.deleteNode({ project: projectName, nodeUuid: error.node.uuid}).take(1).subscribe();
                 throw error.error;
             });


### PR DESCRIPTION
Applies to node-editor and multi-file-upload-dialog