### PR TITLE
Remove displayed schemas/microschemas/projects from state

### DIFF
--- a/src/app/admin/components/create-project-modal/create-project-modal.component.spec.ts
+++ b/src/app/admin/components/create-project-modal/create-project-modal.component.spec.ts
@@ -183,8 +183,7 @@ describe('CreateProjectModal', () => {
                 name: projectName,
                 schema: {
                     uuid: testSchema.uuid,
-                    name: testSchema.name,
-                    version: ''
+                    name: testSchema.name
                 }
             });
         })

--- a/src/app/admin/components/create-project-modal/create-project-modal.component.ts
+++ b/src/app/admin/components/create-project-modal/create-project-modal.component.ts
@@ -21,8 +21,8 @@ export class CreateProjectModalComponent implements IModalDialog, OnInit {
     name: FormControl;
     form: FormGroup;
 
-    creating: boolean = false;
-    conflict: boolean = false;
+    creating = false;
+    conflict = false;
 
     constructor(entities: EntitiesService,
                 private notification: Notification,
@@ -75,9 +75,7 @@ export class CreateProjectModalComponent implements IModalDialog, OnInit {
                 name: this.name.value,
                 schema: {
                     uuid: this.schema.value.uuid,
-                    name: this.schema.value.name,
-                    // TODO: this is required per the generated models, but not needed per the Mesh docs.
-                    version: ''
+                    name: this.schema.value.name
                 }
             };
 

--- a/src/app/admin/components/microschema-list/mircoschema-list.component.ts
+++ b/src/app/admin/components/microschema-list/mircoschema-list.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
 
 import { Microschema } from '../../../common/models/microschema.model';
 import { ApplicationStateService } from '../../../state/providers/application-state.service';
@@ -22,7 +22,7 @@ export class MicroschemaListComponent {
                 private state: ApplicationStateService,
                 private router: Router) {
         this.microschemas$ = entities.selectAllMicroschemas();
-        this.loading$ = state.select(state => state.list.loadCount > 0);
+        this.loading$ = state.select(s => s.list.loadCount > 0);
         this.microschemaEffects.loadMicroschemas();
     }
 

--- a/src/app/admin/components/project-list/project-list.component.spec.ts
+++ b/src/app/admin/components/project-list/project-list.component.spec.ts
@@ -37,9 +37,6 @@ describe('ProjectListComponent', () => {
         appState = TestBed.get(ApplicationStateService);
         appState.trackAllActionCalls({ behavior: 'original' });
         appState.mockState({
-            admin: {
-                displayedProjects: ['55f6a4666eb8467ab6a4666eb8867a84', 'b5eba09ef1554337aba09ef155d337a5']
-            },
             auth: {
                 currentUser: 'd8b043e818144e27b043e81814ae2713'
             }, entities: {
@@ -86,9 +83,6 @@ describe('ProjectListComponent', () => {
         componentTest(() => ProjectListComponent, fixture => {
             fixture.detectChanges();
             appState.mockState({
-                admin: {
-                    displayedProjects: [...appState.now.admin.displayedProjects, 'test3']
-                },
                 entities: {
                     project: {
                         ...appState.now.entities.project,
@@ -97,7 +91,8 @@ describe('ProjectListComponent', () => {
                 }
             });
             fixture.detectChanges();
-            expect(getListedProjectUuids(fixture)).toEqual(['55f6a4666eb8467ab6a4666eb8867a84', 'b5eba09ef1554337aba09ef155d337a5', 'test3']);
+            expect(getListedProjectUuids(fixture))
+                .toEqual(['55f6a4666eb8467ab6a4666eb8867a84', 'b5eba09ef1554337aba09ef155d337a5', 'test3']);
         })
     );
 

--- a/src/app/admin/components/project-list/project-list.component.ts
+++ b/src/app/admin/components/project-list/project-list.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
 import { ModalService } from 'gentics-ui-core';
 
 import { ApplicationStateService } from '../../../state/providers/application-state.service';
@@ -7,6 +7,7 @@ import { CreateProjectModalComponent } from '../create-project-modal/create-proj
 import { hashValues } from '../../../common/util/util';
 import { Project } from '../../../common/models/project.model';
 import { ListEffectsService } from '../../../core/providers/effects/list-effects.service';
+import { EntitiesService } from '../../../state/providers/entities.service';
 
 @Component({
     templateUrl: './project-list.component.html',
@@ -18,12 +19,12 @@ export class ProjectListComponent {
     projectsLoading$: Observable<boolean>;
 
     constructor(private state: ApplicationStateService,
+                private entities: EntitiesService,
                 private modal: ModalService,
                 private listEffects: ListEffectsService) {
-        this.projects$ = state.select(state => state.admin.displayedProjects)
-            .map(uuids => uuids.map(uuid => state.now.entities.project[uuid]));
+        this.projects$ = entities.selectAllProjects();
 
-        this.projectsLoading$ = state.select(state => state.list.loadCount > 0);
+        this.projectsLoading$ = state.select(s => s.list.loadCount > 0);
         this.listEffects.loadProjects();
     }
 

--- a/src/app/admin/components/schema-list/schema-list.component.ts
+++ b/src/app/admin/components/schema-list/schema-list.component.ts
@@ -1,6 +1,6 @@
 import { Router } from '@angular/router';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
 
 import { ApplicationStateService } from '../../../state/providers/application-state.service';
 import { hashValues } from '../../../common/util/util';
@@ -22,7 +22,7 @@ export class SchemaListComponent {
                 private schemaEffects: SchemaEffectsService,
                 private router: Router) {
         this.schemas$ = entities.selectAllSchemas();
-        this.loading$ = state.select(state => state.admin.loadCount > 0);
+        this.loading$ = state.select(s => s.admin.loadCount > 0);
         this.schemaEffects.loadSchemas();
     }
 

--- a/src/app/admin/providers/effects/microschema-effects.service.ts
+++ b/src/app/admin/providers/effects/microschema-effects.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Notification } from 'gentics-ui-core';
-import { Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 
 import { ApiService } from '../../../core/providers/api/api.service';
@@ -96,22 +96,20 @@ export class MicroschemaEffectsService {
         this.state.actions.admin.actionStart();
 
         this.api.admin.deleteMicroschema({microschemaUuid})
-        .subscribe(() => {
+        .do(() => {
             this.state.actions.admin.deleteMicroschemaSuccess(microschemaUuid);
             this.i18nNotification.show({
                 type: 'success',
                 message: 'admin.microschema_deleted'
             });
-            subject.next();
-            subject.complete();
         }, error => {
             this.state.actions.admin.actionError();
             this.notification.show({
                 type: 'error',
                 message: error.toString()
             });
-            subject.error(error);
-        });
+        })
+        .subscribe(subject);
 
         return subject.asObservable();
     }

--- a/src/app/common/util/util.ts
+++ b/src/app/common/util/util.ts
@@ -225,3 +225,15 @@ export function stringToColor(input: string): string {
     }, 0);
     return safeColors[value % safeColors.length];
 }
+
+/**
+ * Remove entries from an object. This does not modify the original object,
+ * but instead creates a new object with the entries removed.
+ * @param input any object
+ * @param keys the keys of the entries to be removed
+ */
+export function removeEntries<T extends object, K extends keyof T>(input: T, ...keys: K[]): any {
+    return Object.keys(input)
+        .filter(key => keys.indexOf(key as K) < 0)
+        .reduce((obj, key) => ({... obj, [key]: input[key]}), {}) as any;
+}

--- a/src/app/core/providers/effects/schema-effects.service.ts
+++ b/src/app/core/providers/effects/schema-effects.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ApiService } from '../api/api.service';
-import { Observable } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 
 import { ApplicationStateService } from '../../../state/providers/application-state.service';
@@ -98,22 +98,19 @@ export class SchemaEffectsService {
         this.state.actions.admin.actionStart();
 
         this.api.admin.deleteSchema({schemaUuid})
-        .subscribe(() => {
+        .do(() => {
             this.state.actions.admin.deleteSchemaSuccess(schemaUuid);
             this.i18nNotification.show({
                 type: 'success',
                 message: 'admin.schema_deleted'
             });
-            subject.next();
-            subject.complete();
         }, error => {
             this.state.actions.admin.actionError();
             this.i18nNotification.show({
                 type: 'error',
                 message: error.toString()
             });
-            subject.error(error);
-        });
+        }).subscribe(subject);
 
         return subject.asObservable();
     }

--- a/src/app/state/models/admin-state.model.ts
+++ b/src/app/state/models/admin-state.model.ts
@@ -15,7 +15,4 @@ export interface AdminState {
     openEntity?: AdminStateEntity;
     /** Assignment of the currently open (micro-)schema to projects. */
     assignedToProject: ProjectAssignments;
-    displayedProjects: string[];
-    displayedSchemas: string[];
-    displayedMicroschemas: string[];
 }

--- a/src/app/state/providers/admin-state-actions.ts
+++ b/src/app/state/providers/admin-state-actions.ts
@@ -8,6 +8,7 @@ import { MicroschemaResponse, ProjectResponse, SchemaResponse } from '../../comm
 import { mergeEntityState } from './entity-state-actions';
 import { Schema } from '../../common/models/schema.model';
 import { Microschema } from '../../common/models/microschema.model';
+import { removeEntries } from '../../common/util/util';
 
 @Injectable()
 @Immutable()
@@ -21,10 +22,7 @@ export class AdminStateActions extends StateActionBranch<AppState> {
             initialState: {
                 admin: {
                     loadCount: 0,
-                    assignedToProject: {},
-                    displayedProjects: [],
-                    displayedSchemas: [],
-                    displayedMicroschemas: []
+                    assignedToProject: {}
                 }
             }
         });
@@ -44,7 +42,6 @@ export class AdminStateActions extends StateActionBranch<AppState> {
 
     loadSchemasSuccess(schemas: Schema[]) {
         this.admin.loadCount--;
-        this.admin.displayedSchemas = schemas.map(schema => schema.uuid);
         this.entities = mergeEntityState(this.entities, {
             schema: schemas
         });
@@ -55,21 +52,29 @@ export class AdminStateActions extends StateActionBranch<AppState> {
         this.entities = mergeEntityState(this.entities, {
             project: [project]
         });
-        this.admin.displayedProjects = [...this.admin.displayedProjects, project.uuid];
-    }
-
-    deleteProjectSuccess(projectUuid: string) {
-        this.admin.displayedProjects = this.admin.displayedProjects.filter(uuid => uuid !== projectUuid);
-    }
-
-    deleteMicroschemaSuccess(microschemaUuid: string) {
-        this.admin.loadCount--;
-        this.admin.displayedMicroschemas = this.admin.displayedMicroschemas.filter(uuid => uuid !== microschemaUuid);
     }
 
     deleteSchemaSuccess(schemaUuid: string) {
         this.admin.loadCount--;
-        this.admin.displayedSchemas = this.admin.displayedSchemas.filter(uuid => uuid !== schemaUuid);
+        this.entities = {
+            ... this.entities,
+            schema: removeEntries(this.entities.schema, schemaUuid)
+        };
+    }
+
+    deleteMicroschemaSuccess(microschemaUuid: string) {
+        this.admin.loadCount--;
+        this.entities = {
+            ... this.entities,
+            microschema: removeEntries(this.entities.microschema, microschemaUuid)
+        };
+    }
+
+    deleteProjectSuccess(uuid: string) {
+        this.entities = {
+            ... this.entities,
+            project: removeEntries(this.entities.project, uuid)
+        };
     }
 
     updateMicroschemaSuccess(response: MicroschemaResponse) {
@@ -84,7 +89,6 @@ export class AdminStateActions extends StateActionBranch<AppState> {
         this.entities = mergeEntityState(this.entities, {
             microschema: [response as Microschema]
         });
-        this.admin.displayedMicroschemas = [...this.admin.displayedMicroschemas, response.uuid];
     }
 
     openMicroschemaStart() {
@@ -127,7 +131,6 @@ export class AdminStateActions extends StateActionBranch<AppState> {
         this.entities = mergeEntityState(this.entities, {
             schema: [response as Schema]
         });
-        this.admin.displayedSchemas = [...this.admin.displayedSchemas, response.uuid];
     }
 
     openSchemaStart() {

--- a/src/app/state/providers/entities.service.ts
+++ b/src/app/state/providers/entities.service.ts
@@ -67,6 +67,14 @@ export class EntitiesService {
         return this.selectWithFilter(state => this.getProjectFromState(state, uuid));
     }
 
+    selectAllProjects(): Observable<Project[]> {
+        return this.state.select(state => this.getAllProjectsFromState(state));
+    }
+
+    private getAllProjectsFromState(state: AppState): Project[] {
+        return Object.keys(state.entities.project).map(uuid => this.getProjectFromState(state, uuid)!);
+    }
+
     private getProjectFromState(state: AppState, uuid: string): Project | undefined {
         return getNestedEntity<'project'>(
             state.entities.project,

--- a/src/app/state/providers/list-state-actions.ts
+++ b/src/app/state/providers/list-state-actions.ts
@@ -78,7 +78,6 @@ export class ListStateActions extends StateActionBranch<AppState> {
         this.entities = mergeEntityState(this.entities, {
             project: projects
         });
-        this.admin.displayedProjects = projects.map(project => project.uuid);
     }
 
     fetchProjectsError() {
@@ -91,7 +90,6 @@ export class ListStateActions extends StateActionBranch<AppState> {
 
     fetchMicroschemasSuccess(microschemas: MicroschemaResponse[]) {
         this.list.loadCount--;
-        this.admin.displayedMicroschemas = microschemas.map(schema => schema.uuid);
         this.entities = mergeEntityState(this.entities, {
             microschema: microschemas as Microschema[]
         });


### PR DESCRIPTION
Instead the entities are taken directly from the entity state. When an entity is deleted, it is also deleted directly from the entity state.