### PR TITLE
fix: limit max height and add autoscroll for dropdown list

### DIFF
--- a/src/app/common/components/dropdown/dropdown.less
+++ b/src/app/common/components/dropdown/dropdown.less
@@ -35,6 +35,8 @@
     box-shadow: 0 5px 21px 0 rgba(0, 0, 0, 0.2);
     background-color: @mh-dropdown-background-color;
     border: 1px solid @color-silver;
+    max-height: 450px;
+    overflow: auto;
   }
 
   ul {


### PR DESCRIPTION
This is a quick and dirty fix to resolve too long dropdown list referenced in this issue:

https://github.com/gentics/mesh/issues/218