### PR TITLE
Fix project explorer select node resetting current page; #194

### DIFF
--- a/src/app/projects/components/explorerContentsList/explorerContentsList.html
+++ b/src/app/projects/components/explorerContentsList/explorerContentsList.html
@@ -13,6 +13,7 @@
                     'untranslated': !vm.isAvailableInCurrentLang(node)
                  }"
                  ng-click="vm.toggleSelect(node, $event)"
+                 current-page="bundle._metainfo.currentPage"
                  layout="row">
 
                 <div flex layout="row" layout-align="start center">

--- a/src/app/projects/projectExplorer/projectExplorerController.ts
+++ b/src/app/projects/projectExplorer/projectExplorerController.ts
@@ -5,6 +5,7 @@ module meshAdminUi {
      */
     class ProjectExplorerController {
 
+        private currentPages: { [schemaUuid: string]: number } = {};
         private itemsPerPage: number = 10;
         private createPermission: boolean;
         private contents: INodeBundleResponse[] = [];
@@ -45,7 +46,10 @@ module meshAdminUi {
                 })
             };
 
-            const searchParamsHandler = () => this.populateChildNodes();
+            const searchParamsHandler = () => {
+              this.currentPages = {};
+              this.populateChildNodes();
+            };
 
             dispatcher.subscribe(dispatcher.events.explorerSearchParamsChanged, searchParamsHandler);
             dispatcher.subscribe(dispatcher.events.explorerContentsChanged, updateContents);
@@ -97,7 +101,7 @@ module meshAdminUi {
             let bundleParams: INodeBundleParams[] = this.childrenSchemas.map(schemaRef => {
                 return {
                     schema: schemaRef,
-                    page: 1
+                    page: this.currentPages[schemaRef.uuid] || 1
                 };
             });
             return this.dataService.getNodeBundles(projectName, this.currentNode, bundleParams, searchParams, queryParams)
@@ -120,6 +124,7 @@ module meshAdminUi {
             return this.dataService.getNodeBundles(this.projectName, this.currentNode, bundleParams, searchParams, {
                 perPage: this.itemsPerPage
             }).then(result => {
+                this.currentPages[schemaUuid] = newPageNumber;
                 var index = this.contents.map(bundle => bundle.schema.uuid).indexOf(schemaUuid);
                 this.contents[index].data = result[0].data;
                 this.contents[index]._metainfo = result[0]._metainfo;


### PR DESCRIPTION
### Summary
This PR resolves an issue where selecting a node in the project explorer would reset the currently selected page, which is annoying when handling schemas with many nodes, in the old UI.

Related issue: #194 (tagged with `new-ui` though, so I guess it's for the new UI only)

### Technical Overview
It accomplishes this by keeping a map of schema UUIDs to their current pages in the explorer controller. The explorer contents list directive uses the metadata provided by the backend to figure out the current page.

### Rationale
In the contents list, this is necessary so that the pagination directive can permanently store the page number in the parent directive. Just storing it in the scope (the default behaviour) was not sufficient - it seems that the page number in the scope gets reset when overwriting the contents array entirely
in `populateChildNodes()` from the explorer controller. Without that, the correct page gets retrieved, but the pagination still shows the wrong page number.

In the explorer, we cannot just use `_metainfo`, because there's no way to know if the search term changed - in that case, we want to reset the page counts (there might not be that many results any more). We could technically overwrite `_metainfo` in the search term change handler, but this seems even worse.

### Caveats
The pagination directive actually uses the page number expression we pass to it as storage. That means, it reads the current page number, but also updates the DTO when the page number changes. (which shouldn't really be modified) This doesn't seem like a huge practical issue since I didn't find any read usages for `INodeBundleResponse._metainfo`.

### Testing
Since all of the current tests seem to cover services only, not controllers, it didn't seem necessary to add an automated test here. I have verified locally that the correct page is now kept when opening a node, page changes work, and page numbers are reset when changing the current node.