### PR TITLE
Validate microschema lists, Node update error handling

### DIFF
--- a/src/app/common/services/dataService.ts
+++ b/src/app/common/services/dataService.ts
@@ -566,6 +566,8 @@ module meshAdminUi {
                             console.warn(`Version conflict detected, forcing update to this version`, err.data);
                             node.version = err.data.properties.newVersion;
                             return this.updateNode(projectName, node, queryParams);
+                        } else {
+                            throw err;
                         }
                     }
                 );

--- a/src/app/projects/components/editorPane/editorPane.ts
+++ b/src/app/projects/components/editorPane/editorPane.ts
@@ -147,7 +147,7 @@ module meshAdminUi {
 
         public readyToPublish(): boolean {
             const isPublished = this.isPublished();
-            return !isPublished || (isPublished && this.contentModified || this.tagsModified);
+            return !isPublished || (isPublished && (this.contentModified || this.tagsModified) && this.formIsValid());
         }
 
         /**
@@ -156,7 +156,7 @@ module meshAdminUi {
         public publish(): void {
             let savePromise: ng.IPromise<any>;
             let savingNode: boolean = false;
-            if (this.contentModified || this.tagsModified) {
+            if ((this.contentModified || this.tagsModified) && this.formIsValid()) {
                 savePromise = this.persist(this.node);
                 savingNode = true;
             } else {
@@ -386,6 +386,19 @@ module meshAdminUi {
                     const microschema = this.microschemas.filter(m => m.name === nodeField.microschema.name)[0];
                     if (microschema) {
                         return microschema.fields.reduce(fieldIsValidReducer(nodeField), valid);
+                    }
+                } else if (field.type === 'list' && field.listType === 'micronode') {
+                    const listField = container.fields[field.name];
+                    if (listField instanceof Array) {
+                        return listField.reduce((listValid: boolean, listItem: any) => {
+                            const microschema = this.microschemas
+                                .filter(m => m.name === listItem.microschema.name)[0];
+                            if (microschema) {
+                                return microschema.fields.reduce(fieldIsValidReducer(listItem), listValid);
+                            } else {
+                                return listValid;
+                            }
+                        }, valid);
                     }
                 }
                 return valid;

--- a/src/app/projects/components/editorPane/editorPane.ts
+++ b/src/app/projects/components/editorPane/editorPane.ts
@@ -179,6 +179,8 @@ module meshAdminUi {
                     .catch(error => {
                        this.notifyService.toast(error.data.message || error.data);
                    });
+            }).catch(error => {
+                this.notifyService.toast(error.data.message || error.data);
             });
         }
 


### PR DESCRIPTION
### Ellipsis
This PR addresses some of the validation issues @xVinci6 talked about on [Gitter](https://gitter.im/gentics/mesh?at=5ca21f311f6e900d5ebe4b62) last week. Specifically, it stops `DataService` from swallowing errors on product updates. Further, it adds active validation to microschema lists. So if there is a validation error in a microschema list, the invalid node can no longer be sent now, stopping the Bad Request errors from happening in the first place.

### Detailed issue description
1. Node update errors are swallowed in `DataService` (no return in `catch` -> mapped to resolved promise with `undefined` as parameter)
2. For the "Save & Publish" button, it seems like it should be possible to publish an existing draft even if the currently entered data is invalid. (caption changes to "Publish") However, this also enables the button if there is no draft to publish. When clicking it, actually, the current version is saved before publishing. Because of (1), the result of the save call is ignored and the changes are lost. The success handler gets `undefined` as argument and fails badly, which is also why the buttons stay hidden.
3. For lists of microschemas, the validity is not validated. Hence, forms are still seen as valid, and the user is able to submit invalid data to get a backend error message.

### Solution
1. Rethrow the error, so that the resulting promise is correctly rejected, with the error.
2. Disable the "Publish" button if there is no saved draft and the current form is invalid. Also, don't try to save invalid forms when publishing.
3. Validate lists of microschemas in the `formIsValid()` method.

### Testing
There were no existing Integration Tests for this, so I did not add any new ones. I have verified that given issues are resolved locally.

If necessary for the workflow, I can split issues 1-3 into separate PRs and create issues.
