### PR TITLE
Added an (simplified)Chinese i18n multilingual support.

### DIFF
--- a/src/app/core/components/language-switcher/language-switcher.component.html
+++ b/src/app/core/components/language-switcher/language-switcher.component.html
@@ -14,5 +14,8 @@
         <gtx-dropdown-item (click)="changeLanguage('en')">
             English
         </gtx-dropdown-item>
+        <gtx-dropdown-item (click)="changeLanguage('zh')">
+            Chinese
+        </gtx-dropdown-item>
     </gtx-dropdown-content>
 </gtx-dropdown-list>

--- a/src/app/core/providers/i18n/i18n.service.ts
+++ b/src/app/core/providers/i18n/i18n.service.ts
@@ -3,7 +3,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { ConfigService } from '../config/config.service';
 
-export type UILanguage = 'en' | 'de';
+export type UILanguage = 'en' | 'de' | 'zh';
 
 @Injectable()
 export class I18nService {

--- a/src/app/core/providers/i18n/translations_json/admin.translations.json
+++ b/src/app/core/providers/i18n/translations_json/admin.translations.json
@@ -1,654 +1,807 @@
 {
     "add_selected_groups_to_role": {
         "en": "Assign {{count}} groups to role",
-        "de": "{{count}} Gruppen zu Rolle zuweisen"
+        "de": "{{count}} Gruppen zu Rolle zuweisen",
+        "zh": "将 {{count}} 个用户组分配给角色"
     },
     "add_selected_users_to_group": {
         "en": "Assign {{count}} users to group",
-        "de": "{{count}} Benutzer zu Gruppe zuweisen"
+        "de": "{{count}} Benutzer zu Gruppe zuweisen",
+        "zh": "分配 {{count}} 个用户到用户组"
     },
     "add_user_to_group": {
         "en": "Assign to group",
-        "de": "Zu Gruppe zuweisen"
+        "de": "Zu Gruppe zuweisen",
+        "zh": "分配给用户组"
     },
     "add_permission_to_role": {
         "en": "Assign to role",
-        "de": "Zu Rolle zuweisen"
+        "de": "Zu Rolle zuweisen",
+        "zh": "分配给角色"
     },
     "all": {
         "en": "all",
-        "de": "alle"
+        "de": "alle",
+        "zh": "全部"
     },
     "all_groups": {
         "en": "All groups",
-        "de": "Alle Gruppen"
+        "de": "Alle Gruppen",
+        "zh": "所有用户组"
     },
     "all_roles": {
         "en": "All roles",
-        "de": "Alle Rollen"
+        "de": "Alle Rollen",
+        "zh": "所有角色"
     },
     "assign_schema": {
         "en": "Assign schema",
-        "de": "Schema zuordnen"
+        "de": "Schema zuordnen",
+        "zh": "分配数据模型"
     },
     "assign_schema_confirmation": {
         "en": "Do you want to assign schema \"{{ name }}\" to a project?",
-        "de": "Wollen Sie das Schema \"{{ name }}\" einem Projekt zuordnen?"
+        "de": "Wollen Sie das Schema \"{{ name }}\" einem Projekt zuordnen?",
+        "zh": "你是否要为项目分配数据模型 \"{{name}}\"？"
     },
     "apply_recursively": {
         "en": "Apply recursively",
-        "de": "Rekursiv anwenden"
+        "de": "Rekursiv anwenden",
+        "zh": "应用到所有子项"
     },
-    "delete_selected_schemas" : {
+    "delete_selected_schemas": {
         "en": "Delete {{count}} schemas",
-        "de": "{{count }} Schemas löschen"
+        "de": "{{count }} Schemas löschen",
+        "zh": "删除 {{count}} 个数据模型"
     },
-    "delete_selected_microschemas" : {
+    "delete_selected_microschemas": {
         "en": "Delete {{count}} microschemas",
-        "de": "{{count }} Microschemas löschen"
+        "de": "{{count }} Microschemas löschen",
+        "zh": "删除 {{count}} 个内嵌数据模型"
     },
     "delete_selected_schemas_confirmation": {
         "en": "You are about to permanently delete {{ count }} schemas.",
-        "de": "Wollen Sie {{ count }} Schemas permanent löschen?"
+        "de": "Wollen Sie {{ count }} Schemas permanent löschen?",
+        "zh": "你将永久删除 {{count}} 个数据模型。"
     },
     "delete_selected_microschemas_confirmation": {
         "en": "You are about to permanently delete {{ count }} microschemas.",
-        "de": "Wollen Sie {{ count }} Microschemas permanent löschen?"
+        "de": "Wollen Sie {{ count }} Microschemas permanent löschen?",
+        "zh": "你将要永久删除 {{count}} 个内嵌数据模型。"
     },
     "delete_schema": {
         "en": "Delete schema",
-        "de": "Schema löschen"
+        "de": "Schema löschen",
+        "zh": "删除数据模型"
     },
     "delete_schemafield": {
         "en": "Delete schemafield",
-        "de": "Schemafeld löschen"
+        "de": "Schemafeld löschen",
+        "zh": "删除数据模型字段"
     },
     "delete_microschema": {
         "en": "Delete microschema",
-        "de": "Microschema löschen"
+        "de": "Microschema löschen",
+        "zh": "删除内嵌数据模型"
     },
     "delete_schema_confirmation": {
         "en": "You are about to permanently delete schema '{{ name }}'.",
-        "de": "Wollen Sie '{{ name }}' permanent löschen?"
+        "de": "Wollen Sie '{{ name }}' permanent löschen?",
+        "zh": "你将要永久删除数据模型'{{name}}'。"
     },
     "delete_microschema_confirmation": {
         "en": "You are about to permanently delete microschema '{{ name }}'.",
-        "de": "Wollen Sie '{{ name }}' permanent löschen?"
+        "de": "Wollen Sie '{{ name }}' permanent löschen?",
+        "zh": "你将永久删除内嵌数据模型'{{name}}'。"
     },
     "assigned_to_projects": {
         "en": "Assigned to projects",
-        "de": "Zugewiesen zu Projekte"
+        "de": "Zugewiesen zu Projekte",
+        "zh": "分配给项目"
     },
     "create_group": {
         "en": "Create group",
-        "de": "Gruppe erstellen"
+        "de": "Gruppe erstellen",
+        "zh": "创建用户组"
     },
     "create_role": {
         "en": "Create role",
-        "de": "Rolle erstellen"
+        "de": "Rolle erstellen",
+        "zh": "创建角色"
     },
     "create_tag": {
         "en": "Create tag",
-        "de": "Tag erstellen"
+        "de": "Tag erstellen",
+        "zh": "创建标签"
     },
     "create_user": {
         "en": "Create user",
-        "de": "Benutzer erstellen"
+        "de": "Benutzer erstellen",
+        "zh": "创建用户"
     },
     "delete_group": {
         "en": "Delete group",
-        "de": "Gruppe löschen"
+        "de": "Gruppe löschen",
+        "zh": "删除用户组"
     },
     "delete_role": {
         "en": "Delete role",
-        "de": "Rolle löschen"
+        "de": "Rolle löschen",
+        "zh": "删除角色"
     },
     "delete_label": {
         "en": "Delete",
-        "de": "Löschen"
+        "de": "Löschen",
+        "zh": "删除"
     },
     "delete_selected_users": {
         "en": "Delete {{ count }} users",
-        "de": "{{ count }} Benutzer löschen"
+        "de": "{{ count }} Benutzer löschen",
+        "zh": "删除 {{count}} 个用户"
     },
     "delete_selected_users_confirmation": {
         "en": "You are about to permanently delete {{ count }} users.",
-        "de": "Wollen Sie {{ count }} Benutzer permanent löschen?"
+        "de": "Wollen Sie {{ count }} Benutzer permanent löschen?",
+        "zh": "你将要永久删除 {{count}} 个用户。"
     },
     "delete_user": {
         "en": "Delete user",
-        "de": "Benutzer löschen"
+        "de": "Benutzer löschen",
+        "zh": "删除用户"
     },
     "delete_user_confirmation": {
         "en": "You are about to permanently delete user '{{ username }}'.",
-        "de": "Wollen Sie '{{ username }}' permanent löschen?"
+        "de": "Wollen Sie '{{ username }}' permanent löschen?",
+        "zh": "你将永久删除用户 '{{username}}'。"
     },
     "delete_selected_groups": {
         "en": "Delete {{ count }} groups",
-        "de": "{{ count }} Gruppen löschen"
+        "de": "{{ count }} Gruppen löschen",
+        "zh": "删除 {{count}} 个用户组"
     },
     "delete_selected_groups_confirmation": {
         "en": "You are about to permanently delete {{ count }} groups.",
-        "de": "Wollen Sie {{ count }} Gruppen permanent löschen?"
+        "de": "Wollen Sie {{ count }} Gruppen permanent löschen?",
+        "zh": "你将要永久删除 {{count}} 个用户组。"
     },
     "delete_group_confirmation": {
         "en": "You are about to permanently delete group '{{ groupname }}'.",
-        "de": "Wollen Sie '{{ groupname }}' permanent löschen?"
+        "de": "Wollen Sie '{{ groupname }}' permanent löschen?",
+        "zh": "你将要永久删除用户组 '{{groupname}}'。"
     },
     "delete_selected_roles": {
         "en": "Delete {{ count }} roles",
-        "de": "{{ count }} Rollen löschen"
+        "de": "{{ count }} Rollen löschen",
+        "zh": "删除 {{count}} 个角色"
     },
     "delete_selected_roles_confirmation": {
         "en": "You are about to permanently delete {{ count }} roles.",
-        "de": "Wollen Sie {{ count }} Rollen permanent löschen?"
+        "de": "Wollen Sie {{ count }} Rollen permanent löschen?",
+        "zh": "你将要永久删除 {{count}} 个角色。"
     },
     "delete_role_confirmation": {
         "en": "You are about to permanently delete role '{{ rolename }}'.",
-        "de": "Wollen Sie '{{ rolename }}' permanent löschen?"
+        "de": "Wollen Sie '{{ rolename }}' permanent löschen?",
+        "zh": "你将要永久删除角色 \"{{rolename}}\"。"
     },
     "edit_user_node": {
         "en": "Edit node",
-        "de": "Node bearbeiten"
+        "de": "Node bearbeiten",
+        "zh": "编辑节点"
     },
     "email_address_label": {
         "en": "Email address",
-        "de": "Email-Addresse"
+        "de": "Email-Addresse",
+        "zh": "电子邮件地址"
     },
     "filter_by_group": {
         "en": "Filter by group",
-        "de": "nach Gruppe durchsuchen"
+        "de": "nach Gruppe durchsuchen",
+        "zh": "按用户组过滤"
     },
     "filter_by_name": {
         "en": "Filter by name",
-        "de": "nach Name durchsuchen"
+        "de": "nach Name durchsuchen",
+        "zh": "按名称过滤"
     },
     "filter_by_role": {
         "en": "Filter by role",
-        "de": "nach Rolle durchsuchen"
+        "de": "nach Rolle durchsuchen",
+        "zh": "按角色过滤"
     },
     "first_name_label": {
         "en": "First name",
-        "de": "Vorname"
+        "de": "Vorname",
+        "zh": "名字"
     },
     "forced_password_change_label": {
         "en": "Force user to change password on login",
-        "de": "Benutzer muss Passwort beim nächsten Login ändern"
+        "de": "Benutzer muss Passwort beim nächsten Login ändern",
+        "zh": "强制用户在登录时更改密码"
     },
     "group_created": {
         "en": "New group created",
-        "de": "Neue Gruppe erstellt"
+        "de": "Neue Gruppe erstellt",
+        "zh": "已创建用户组"
     },
     "group_deleted": {
         "en": "Group deleted",
-        "de": "Gruppe gelöscht"
+        "de": "Gruppe gelöscht",
+        "zh": "用户组已删除"
     },
     "group_updated": {
         "en": "Group updated",
-        "de": "Gruppe gespeichert"
+        "de": "Gruppe gespeichert",
+        "zh": "已更新用户组"
     },
     "groups_deleted": {
         "en": "Groups deleted",
-        "de": "Gruppen gelöscht"
+        "de": "Gruppen gelöscht",
+        "zh": "用户组已删除"
     },
     "group_name_label": {
         "en": "Group name",
-        "de": "Gruppenname"
+        "de": "Gruppenname",
+        "zh": "用户组名"
     },
     "role_created": {
         "en": "New role created",
-        "de": "Neue Rolle erstellt"
+        "de": "Neue Rolle erstellt",
+        "zh": "已创建新角色"
     },
     "role_deleted": {
         "en": "Role deleted",
-        "de": "Rolle gelöscht"
+        "de": "Rolle gelöscht",
+        "zh": "角色已删除"
     },
     "role_updated": {
         "en": "Role updated",
-        "de": "Rolle gespeichert"
+        "de": "Rolle gespeichert",
+        "zh": "角色已更新"
     },
     "role_name_label": {
         "en": "Role name",
-        "de": "Rollenname"
+        "de": "Rollenname",
+        "zh": "角色名称"
     },
     "last_name_label": {
         "en": "Last name",
-        "de": "Nachname"
+        "de": "Nachname",
+        "zh": "姓氏"
     },
     "list_clear_selection": {
         "en": "clear selection",
-        "de": "Auswahl aufheben"
+        "de": "Auswahl aufheben",
+        "zh": "清除选择"
     },
     "list_items_selected": {
         "en": "Selected: {{ count }}",
-        "de": "Ausgewählt: {{ count }}"
+        "de": "Ausgewählt: {{ count }}",
+        "zh": "已选择：{{count}}"
     },
     "microschema_create": {
         "en": "Create Microschema",
-        "de": "Microschema erstellen"
+        "de": "Microschema erstellen",
+        "zh": "创建内嵌数据模型"
     },
     "microschema_deleted": {
         "en": "Microschema deleted",
-        "de": "Microschema gelöscht"
+        "de": "Microschema gelöscht",
+        "zh": "内嵌数据模型已删除"
     },
     "microschema_deleted_error": {
         "en": "Microschema could not be deleted",
-        "de": "Microschema konnte nicht gelöscht werden"
+        "de": "Microschema konnte nicht gelöscht werden",
+        "zh": "无法删除内嵌数据模型"
     },
     "microschema_created": {
         "en": "Microschema created",
-        "de": "Microschema erstellt"
+        "de": "Microschema erstellt",
+        "zh": "已创建内嵌数据模型"
     },
     "microschema_updated": {
         "en": "Microschema updated",
-        "de": "Microschema gespeichert"
+        "de": "Microschema gespeichert",
+        "zh": "内嵌数据模型已更新"
     },
     "microschema_none_found": {
         "en": "No microschemas found",
-        "de": "Keine Microschemas gefunden"
+        "de": "Keine Microschemas gefunden",
+        "zh": "未找到内嵌数据模型"
     },
     "new_group": {
         "en": "New group",
-        "de": "Neue Gruppe"
+        "de": "Neue Gruppe",
+        "zh": "新建用户组"
     },
     "new_role": {
         "en": "New role",
-        "de": "Neue Rolle"
+        "de": "Neue Rolle",
+        "zh": "新角色"
     },
     "new_project": {
         "en": "New project",
-        "de": "Neues Projekt"
+        "de": "Neues Projekt",
+        "zh": "新建项目"
     },
     "new_user": {
         "en": "New user",
-        "de": "Neuer Benutzer"
+        "de": "Neuer Benutzer",
+        "zh": "新用户"
     },
     "new_microschema": {
         "en": "New microschema",
-        "de": "Neues Microschema"
+        "de": "Neues Microschema",
+        "zh": "新建内嵌数据模型"
     },
     "new_schema": {
         "en": "New schema",
-        "de": "Neues Schema"
+        "de": "Neues Schema",
+        "zh": "新建数据模型"
     },
     "no_available_groups": {
         "en": "No available groups",
-        "de": "Keine gültige Gruppen"
+        "de": "Keine gültige Gruppen",
+        "zh": "没有可用的用户组"
     },
     "no_available_roles": {
         "en": "No available roles",
-        "de": "Keine gültige Rollen"
+        "de": "Keine gültige Rollen",
+        "zh": "没有可用的角色"
     },
     "no_results": {
         "en": "No results",
-        "de": "Keine Ergebnisse"
+        "de": "Keine Ergebnisse",
+        "zh": "未找到结果"
     },
     "password_label": {
         "en": "Password",
-        "de": "Kennwort"
+        "de": "Kennwort",
+        "zh": "密码"
     },
     "projects_create": {
         "en": "Create project",
-        "de": "Projekt erstellen"
+        "de": "Projekt erstellen",
+        "zh": "创建项目"
     },
     "project_created": {
         "en": "Project created",
-        "de": "Projekt erstellt"
+        "de": "Projekt erstellt",
+        "zh": "项目已创建"
     },
     "project_assigned": {
         "en": "Project assigned",
-        "de": "Projekt zugewiesen"
+        "de": "Projekt zugewiesen",
+        "zh": "项目已分配"
     },
     "project_unassigned": {
         "en": "Project unassigned",
-        "de": "Projekt unzugewiesen"
+        "de": "Projekt unzugewiesen",
+        "zh": "未分配项目"
     },
     "delete_project": {
         "en": "Delete project",
-        "de": "Projekt löschen"
+        "de": "Projekt löschen",
+        "zh": "删除项目"
     },
     "project_deleted": {
         "en": "Project deleted",
-        "de": "Projekt gelöscht"
+        "de": "Projekt gelöscht",
+        "zh": "项目已删除"
     },
     "project_deleted_error": {
         "en": "Project could not be deleted",
-        "de": "Projekt konnte nicht gelöscht werden"
+        "de": "Projekt konnte nicht gelöscht werden",
+        "zh": "无法删除项目"
     },
     "projects_none_found": {
         "en": "No projects found",
-        "de": "Keine Projekte gefunden"
+        "de": "Keine Projekte gefunden",
+        "zh": "未找到项目"
     },
     "project_label": {
         "en": "Project",
-        "de": "Projekt"
+        "de": "Projekt",
+        "zh": "项目"
     },
     "project_tags": {
         "en": "Project tags",
-        "de": "Tags im Projekt"
+        "de": "Tags im Projekt",
+        "zh": "项目标签"
     },
     "create_tag_family": {
         "en": "Create new tag family",
-        "de": "Neue Tag-Familie erstellen"
+        "de": "Neue Tag-Familie erstellen",
+        "zh": "创建新的标签组"
     },
     "edit_tag_family": {
         "en": "Edit tag family",
-        "de": "Tag-Familie bearbeiten"
+        "de": "Tag-Familie bearbeiten",
+        "zh": "编辑标签组"
     },
     "delete_tag_family": {
         "en": "Delete tag family",
-        "de": "Tag-Familie löschen"
+        "de": "Tag-Familie löschen",
+        "zh": "删除标签组"
     },
     "delete_tag_family_confirmation": {
         "en": "Delete this tag family and all tags?",
-        "de": "Diese Tag-Familie und all ihre Tags löschen?"
+        "de": "Diese Tag-Familie und all ihre Tags löschen?",
+        "zh": "要删除该标签组和所有标签？"
     },
     "edit_tag": {
         "en": "Edit tag",
-        "de": "Tag bearbeiten"
+        "de": "Tag bearbeiten",
+        "zh": "编辑标签"
     },
     "delete_tag_confirmation": {
         "en": "Delete this tag?",
-        "de": "Tag löschen?"
+        "de": "Tag löschen?",
+        "zh": "删除该标签？"
     },
     "duplicate_tag": {
         "en": "Tag \"{{tag}}\" already exists",
-        "de": "Der Tag \"{{tag}}\" existiert bereits."
+        "de": "Der Tag \"{{tag}}\" existiert bereits.",
+        "zh": "标签 \"{{tag}}\" 已存在"
     },
     "duplicate_tag_family": {
         "en": "Tag family \"{{family}}\" already exists",
-        "de": "Die Tagfamillie \"{{family}}\" existiert bereits."
+        "de": "Die Tagfamillie \"{{family}}\" existiert bereits.",
+        "zh": "标签组 \"{{family}}\" 已经存在"
     },
     "update_project": {
         "en": "Update Project",
-        "de": "Projekt speichern"
+        "de": "Projekt speichern",
+        "zh": "更新项目"
     },
     "remove_selected_groups_from_role": {
         "en": "Remove {{count}} groups from role",
-        "de": "{{count}} Gruppen von Rolle entfernen"
+        "de": "{{count}} Gruppen von Rolle entfernen",
+        "zh": "从角色中删除 {{count}} 个用户组"
     },
     "remove_selected_users_from_group": {
         "en": "Remove {{count}} users from group",
-        "de": "{{count}} Benutzer von Gruppe entfernen"
+        "de": "{{count}} Benutzer von Gruppe entfernen",
+        "zh": "从用户组中删除 {{count}} 个用户"
     },
     "remove_user_from_group": {
         "en": "Remove from group",
-        "de": "Von Gruppe entfernen"
+        "de": "Von Gruppe entfernen",
+        "zh": "从用户组中删除"
     },
     "remove_group_from_role": {
         "en": "Remove from role",
-        "de": "Von Rolle entfernen"
+        "de": "Von Rolle entfernen",
+        "zh": "从角色中移除"
     },
     "schema_create": {
         "en": "Create Schema",
-        "de": "Schema erstellen"
+        "de": "Schema erstellen",
+        "zh": "创建数据模型"
     },
     "schema_update": {
         "en": "Save Schema",
-        "de": "Schema speichern"
+        "de": "Schema speichern",
+        "zh": "保存数据模型"
     },
     "schema_deleted": {
         "en": "Schema deleted",
-        "de": "Schema gelöscht"
+        "de": "Schema gelöscht",
+        "zh": "数据模型已删除"
     },
     "schema_deleted_error": {
         "en": "Schema could not be deleted",
-        "de": "Schema konnte nicht gelöscht werden"
+        "de": "Schema konnte nicht gelöscht werden",
+        "zh": "数据模型无法删除"
     },
     "schema_created": {
         "en": "Schema created",
-        "de": "Schema erstellt"
+        "de": "Schema erstellt",
+        "zh": "已创建数据模型"
     },
     "schema_updated": {
         "en": "Schema updated",
-        "de": "Schema gespeichert"
+        "de": "Schema gespeichert",
+        "zh": "数据模型已更新"
     },
     "schema_updated_confirmation": {
         "en": "You are about to save schema '{{ name }}'.",
-        "de": "Wollen Sie '{{ name }}' speichern?"
+        "de": "Wollen Sie '{{ name }}' speichern?",
+        "zh": "你将要保存数据模型 '{{name}}'。"
     },
     "schemafield_delete_confirmation": {
         "en": "You are about to delete schemafield '{{ name }}'.",
-        "de": "Wollen Sie das Schemafeld'{{ name }}' löschen?"
+        "de": "Wollen Sie das Schemafeld'{{ name }}' löschen?",
+        "zh": "你将要删除数据模型字段'{{name}}'。"
     },
     "schema_none_found": {
         "en": "No schemas found",
-        "de": "Keine Schemas gefunden"
+        "de": "Keine Schemas gefunden",
+        "zh": "未找到数据模型"
     },
     "select_all": {
         "en": "Select all",
-        "de": "Alle auswählen"
+        "de": "Alle auswählen",
+        "zh": "全选"
     },
     "select_node_reference": {
         "en": "Select node",
-        "de": "Node auswählen"
+        "de": "Node auswählen",
+        "zh": "选择节点"
     },
     "select_new_node_reference": {
         "en": "Select a different node",
-        "de": "Andere Node auswählen"
+        "de": "Andere Node auswählen",
+        "zh": "选择其他节点"
     },
     "tag": {
         "en": "Tag",
-        "de": "Tag"
+        "de": "Tag",
+        "zh": "标签"
     },
     "update_group": {
         "en": "Update group",
-        "de": "Gruppe speichern"
+        "de": "Gruppe speichern",
+        "zh": "更新用户组"
     },
     "update_role": {
         "en": "Update role",
-        "de": "Rolle speichern"
+        "de": "Rolle speichern",
+        "zh": "更新角色"
     },
     "update_user": {
         "en": "Update user",
-        "de": "Benutzer speichern"
+        "de": "Benutzer speichern",
+        "zh": "更新用户"
     },
     "user_created": {
         "en": "New user created",
-        "de": "Neuer Benutzer erstellt"
+        "de": "Neuer Benutzer erstellt",
+        "zh": "已创建新用户"
     },
     "user_deleted": {
         "en": "User '{{username}}' deleted",
-        "de": "Benutzer '{{username}}' gelöscht"
+        "de": "Benutzer '{{username}}' gelöscht",
+        "zh": "用户 '{{username}}' 已删除"
     },
     "user_deleted_error": {
         "en": "User '{{username}}' could not be deleted",
-        "de": "Benutzer '{{username}}' könnte nicht gelöscht werden"
+        "de": "Benutzer '{{username}}' könnte nicht gelöscht werden",
+        "zh": "用户 '{{username}}' 无法删除"
     },
     "user_name_label": {
         "en": "Username",
-        "de": "Benutzername"
+        "de": "Benutzername",
+        "zh": "用户名"
     },
     "user_node_reference_label": {
         "en": "User Node",
-        "de": "Benutzer Node"
+        "de": "Benutzer Node",
+        "zh": "用户节点"
     },
     "user_updated": {
         "en": "User updated",
-        "de": "Benutzer gespeichert"
+        "de": "Benutzer gespeichert",
+        "zh": "用户已更新"
     },
-
     "schema_details_tab_label_editor": {
         "en": "Editor",
-        "de": "Editor"
+        "de": "Editor",
+        "zh": "编辑器"
     },
     "schema_details_tab_label_json": {
         "en": "JSON",
-        "de": "JSON"
+        "de": "JSON",
+        "zh": "JSON"
     },
     "schema_details_tab_label_projects": {
         "en": "Project Assignments",
-        "de": "Projektzuordnungen"
+        "de": "Projektzuordnungen",
+        "zh": "项目分配"
     },
-
     "schema_editor_validator_pattern": {
         "en": "This field may contain allowed charaters only: alphanumeric characters and {{allowedchars}}",
-        "de": "Für die Eingabe sind nur folgende Zeichen erlaubt: alphanumerische Zeichen und {{allowedchars}}"
+        "de": "Für die Eingabe sind nur folgende Zeichen erlaubt: alphanumerische Zeichen und {{allowedchars}}",
+        "zh": "此字段只能包含允许的字符：数字、字母和{{allowedchars}}"
     },
     "schema_editor_validator_duplicate": {
         "en": "This value is already in use",
-        "de": "Dieser Wert wird bereits verwendet"
+        "de": "Dieser Wert wird bereits verwendet",
+        "zh": "该值已被使用"
     },
     "schema_editor_validator_conflict": {
         "en": "This value is already in use",
-        "de": "Dieser Wert wird bereits verwendet"
+        "de": "Dieser Wert wird bereits verwendet",
+        "zh": "该值已被使用"
     },
-
     "schema_editor_warning_displayfield": {
         "en": "Create valid schema field of type 'binary' or 'string'",
-        "de": "Erstellen Sie ein gültiges Feld vom Typ 'binary' oder 'string'"
+        "de": "Erstellen Sie ein gültiges Feld vom Typ 'binary' oder 'string'",
+        "zh": "创建类型为'binary'或'string'的有效数据模型字段"
     },
     "schema_editor_warning_segmentfield": {
         "en": "Create valid schema field of type 'binary' or 'string'",
-        "de": "Erstellen Sie ein gültiges Feld vom Typ 'binary' oder 'string'"
+        "de": "Erstellen Sie ein gültiges Feld vom Typ 'binary' oder 'string'",
+        "zh": "创建类型为'binary'或'string'的有效数据模型字段"
     },
     "schema_editor_warning_urlfield": {
         "en": "Create valid schema field of type 'string' or type 'list' of list type 'string'",
-        "de": "Erstellen Sie ein gültiges Feld vom Typ 'string' oder 'list' mit Listentyp 'string'"
+        "de": "Erstellen Sie ein gültiges Feld vom Typ 'string' oder 'list' mit Listentyp 'string'",
+        "zh": "创建类型为'string'或列表类型为'string'的有效数据模型字段"
     },
     "schema_editor_warning_nofields": {
         "en": "This Schema has no fields",
-        "de": "Dieses Schema hat keine Felder"
+        "de": "Dieses Schema hat keine Felder",
+        "zh": "此数据模型没有字段"
     },
-
     "schema_editor_placeholder_allowedstrings": {
         "en": "Type and press ENTER or SPACE to add, BACKSPACE to remove",
-        "de": "Tippen und EINGABE oder LEER drücken zum hinzufügen, RÜCK zum entfernen"
+        "de": "Tippen und EINGABE oder LEER drücken zum hinzufügen, RÜCK zum entfernen",
+        "zh": "输入并按 回车键 或 空格键 添加，按 回退键 删除"
     },
-
     "schema_editor_sectionlabel_schemaproperties": {
         "en": "Schema Properties",
-        "de": "Schemaeigenschaften"
+        "de": "Schemaeigenschaften",
+        "zh": "数据模型属性"
     },
     "schema_editor_sectionlabel_schemafields": {
         "en": "Schema Fields",
-        "de": "Schemafelder"
+        "de": "Schemafelder",
+        "zh": "数据模型字段"
     },
     "schema_editor_sectionlabel_microschemaproperties": {
         "en": "Microschema Properties",
-        "de": "Mikroschemaeigenschaften"
+        "de": "Mikroschemaeigenschaften",
+        "zh": "内嵌数据模型属性"
     },
     "schema_editor_sectionlabel_microschemafields": {
         "en": "Microschema Fields",
-        "de": "Mikroschemafelder"
+        "de": "Mikroschemafelder",
+        "zh": "内嵌数据模型字段"
     },
-
     "schema_editor_inputlabel_name": {
         "en": "Name *",
-        "de": "Name *"
+        "de": "Name *",
+        "zh": "名称 *"
     },
     "schema_editor_inputlabel_container": {
         "en": "Container",
-        "de": "Container"
+        "de": "Container",
+        "zh": "容器"
     },
     "schema_editor_inputlabel_autopurge": {
         "en": "Auto Purge",
-        "de": "Auto-Purge"
+        "de": "Auto-Purge",
+        "zh": "自动清除"
     },
     "schema_editor_inputlabel_description": {
         "en": "Description",
-        "de": "Beschreibung"
+        "de": "Beschreibung",
+        "zh": "描述"
     },
     "schema_editor_inputlabel_displayfield": {
         "en": "Display Field",
-        "de": "Display-Feld"
+        "de": "Display-Feld",
+        "zh": "显示栏"
     },
     "schema_editor_inputlabel_segmentfield": {
         "en": "Segment Field",
-        "de": "Segment-Feld"
+        "de": "Segment-Feld",
+        "zh": "分节字段"
     },
     "schema_editor_inputlabel_urlfield": {
         "en": "URL Field",
-        "de": "URL-Feld"
+        "de": "URL-Feld",
+        "zh": "URL字段"
     },
     "schema_editor_inputlabel_label": {
         "en": "Label",
-        "de": "Anzeigename"
+        "de": "Anzeigename",
+        "zh": "显示"
     },
     "schema_editor_inputlabel_type": {
         "en": "Type *",
-        "de": "Typ *"
+        "de": "Typ *",
+        "zh": "类型 *"
     },
     "schema_editor_inputlabel_required": {
         "en": "Required",
-        "de": "Erforderlich"
+        "de": "Erforderlich",
+        "zh": "必填"
     },
     "schema_editor_inputlabel_listtype": {
         "en": "List Type",
-        "de": "Listentyp"
+        "de": "Listentyp",
+        "zh": "列表类型"
     },
     "schema_editor_inputlabel_allowedschemas": {
         "en": "Allowed Schemas",
-        "de": "Erlaubte Schemata"
+        "de": "Erlaubte Schemata",
+        "zh": "允许的数据模型"
     },
     "schema_editor_inputlabel_allowedmicroschemas": {
         "en": "Allowed Microschemas",
-        "de": "Erlaubte Mikroschemata"
+        "de": "Erlaubte Mikroschemata",
+        "zh": "允许的内嵌数据模型"
     },
     "schema_editor_inputlabel_allowedstrings": {
         "en": "Allowed Strings",
-        "de": "Erlaubte Zeichenketten"
+        "de": "Erlaubte Zeichenketten",
+        "zh": "允许的字符串"
     },
-
     "schema_editor_buttonlabel_newfield": {
         "en": "New Field",
-        "de": "Neues Feld"
+        "de": "Neues Feld",
+        "zh": "新建字段"
     },
     "schema_editor_buttonlabel_create": {
         "en": "Create",
-        "de": "Erstellen"
+        "de": "Erstellen",
+        "zh": "创建"
     },
     "schema_editor_buttonlabel_save": {
         "en": "Save",
-        "de": "Speichern"
+        "de": "Speichern",
+        "zh": "保存"
     },
     "schema_editor_buttonlabel_delete": {
         "en": "Delete",
-        "de": "Löschen"
+        "de": "Löschen",
+        "zh": "删除"
     },
-
     "schema_editor_tooltip_insertnewfield": {
         "en": "Insert new field",
-        "de": "Neues Feld einfügen"
+        "de": "Neues Feld einfügen",
+        "zh": "插入新字段"
     },
     "schema_editor_tooltip_removefield": {
         "en": "Remove field",
-        "de": "Feld entfernen"
+        "de": "Feld entfernen",
+        "zh": "删除字段"
     },
     "load_more": {
         "en": "Load more",
-        "de": "Weitere laden"
+        "de": "Weitere laden",
+        "zh": "加载更多"
     },
     "entity_name_projects": {
         "en": "Projects",
-        "de": "Projekte"
+        "de": "Projekte",
+        "zh": "项目"
     },
     "entity_name_nodes": {
         "en": "Nodes",
-        "de": "Nodes"
+        "de": "Nodes",
+        "zh": "节点"
     },
     "entity_name_tags": {
         "en": "Tags",
-        "de": "Tags"
+        "de": "Tags",
+        "zh": "标签"
     },
     "entity_name_schemas": {
         "en": "Schemas",
-        "de": "Schemas"
+        "de": "Schemas",
+        "zh": "数据模型"
     },
     "entity_name_microschemas": {
         "en": "Microschemas",
-        "de": "Microschemas"
+        "de": "Microschemas",
+        "zh": "内嵌数据模型"
     },
     "entity_name_users": {
         "en": "Users",
-        "de": "Benutzer"
+        "de": "Benutzer",
+        "zh": "用户"
     },
     "entity_name_groups": {
         "en": "Groups",
-        "de": "Gruppen"
+        "de": "Gruppen",
+        "zh": "用户组"
     },
     "entity_name_roles": {
         "en": "Roles",
-        "de": "Rollen"
+        "de": "Rollen",
+        "zh": "角色"
     }
 }

--- a/src/app/core/providers/i18n/translations_json/auth.translations.json
+++ b/src/app/core/providers/i18n/translations_json/auth.translations.json
@@ -1,26 +1,37 @@
 {
     "auth_error": {
       "en": "Login failed",
-      "de": "Anmeldung fehlgeschlagen"
+      "de": "Anmeldung fehlgeschlagen",
+      "zh": "登录失败"
     },
     "change_password": {
       "en": "Change password",
-      "de": "Passwort ändern"
+      "de": "Passwort ändern",
+      "zh": "更改密码"
+    },
+    "login": {
+      "en": "Log In",
+      "de": "Einzuloggen",
+      "zh": "登录"
     },
     "logout": {
-      "en": "Log out",
-      "de": "Ausloggen"
+        "en": "Log out",
+        "de": "Ausloggen",
+        "zh": "退出登录"
     },
     "forced_password_change_message": {
       "en": "You have to change your password to login.",
-      "de": "Sie müssen Ihr Passwort ändern, um sich einzuloggen."
+      "de": "Sie müssen Ihr Passwort ändern, um sich einzuloggen.",
+      "zh": "你必须更改密码才能登录。"
     },
     "password_mismatch": {
       "en": "Password doesn't match",
-      "de": "Die Passwörter stimmen nicht überein"
+      "de": "Die Passwörter stimmen nicht überein",
+      "zh": "密码不匹配"
     },
     "session_expired": {
       "en": "Your session has expired. Please login again.",
-      "de": "Ihre Sitzung ist abgelaufen. Bitte loggen Sie sich erneut ein."
+      "de": "Ihre Sitzung ist abgelaufen. Bitte loggen Sie sich erneut ein.",
+      "zh": "你的会话已过期。 请重新登录。"
     }
 }

--- a/src/app/core/providers/i18n/translations_json/common.translations.json
+++ b/src/app/core/providers/i18n/translations_json/common.translations.json
@@ -1,374 +1,467 @@
 {
     "apply_button": {
       "en": "Apply",
-      "de": "Übernehmen"
+      "de": "Übernehmen",
+      "zh": "应用"
     },
     "apply_recursively_label": {
       "en": "Apply recursively",
-      "de": "Rekursiv übernehmen"
+      "de": "Rekursiv übernehmen",
+      "zh": "应用到所有子项"
     },
     "apply_recursively_button": {
       "en": "Apply recursively",
-      "de": "Rekursiv übernehmen"
+      "de": "Rekursiv übernehmen",
+      "zh": "应用到所有子项"
     },
     "at": {
       "en": "at",
-      "de": "am"
+      "de": "am",
+      "zh": "at"
     },
     "cancel_button": {
       "en": "Cancel",
-      "de": "Abbrechen"
+      "de": "Abbrechen",
+      "zh": "取消"
     },
     "choose": {
       "en": "Choose",
-      "de": "Auswählen"
+      "de": "Auswählen",
+      "zh": "选择"
     },
     "close_button": {
       "en": "Close",
-      "de": "Schließen"
+      "de": "Schließen",
+      "zh": "关闭"
     },
     "creator_label": {
       "en": "Creator",
-      "de": "Erstellt von"
+      "de": "Erstellt von",
+      "zh": "创建者"
     },
     "copy": {
       "en": "copy",
-      "de": "Kopie"
+      "de": "Kopie",
+      "zh": "复制"
     },
     "date_created_label": {
       "en": "Date created",
-      "de": "Erstellt am"
+      "de": "Erstellt am",
+      "zh": "创建日期"
     },
     "date_edited_label": {
       "en": "Date edited",
-      "de": "Bearbeitet am"
+      "de": "Bearbeitet am",
+      "zh": "修改日期"
     },
     "delete_button": {
       "en": "Delete",
-      "de": "Löschen"
+      "de": "Löschen",
+      "zh": "删除"
     },
     "editor_label": {
       "en": "Editor",
-      "de": "Bearbeitet von"
+      "de": "Bearbeitet von",
+      "zh": "编辑者"
     },
     "file_size_label": {
       "en": "File size",
-      "de": "Dateigröße"
+      "de": "Dateigröße",
+      "zh": "文件大小"
     },
     "file_type_label": {
       "en": "File type",
-      "de": "Dateityp"
+      "de": "Dateityp",
+      "zh": "文件类型"
     },
     "id_label": {
       "en": "ID",
-      "de": "ID"
+      "de": "ID",
+      "zh": "ID"
     },
     "last_edited": {
       "en": "last edited",
-      "de": "zuletzt bearbeitet"
+      "de": "zuletzt bearbeitet",
+      "zh": "最后编辑"
     },
     "not_found": {
       "en": "Not found",
-      "de": "Nicht gefunden"
+      "de": "Nicht gefunden",
+      "zh": "未找到"
     },
     "page_not_found": {
       "en": "The URL you entered is not available.",
-      "de": "Die eingegebene URL ist nicht verfügbar."
+      "de": "Die eingegebene URL ist nicht verfügbar.",
+      "zh": "你输入的URL不可用。"
     },
     "navigate_to_fallback": {
       "en": "Navigate to Editor",
-      "de": "Zum Editor navigieren"
+      "de": "Zum Editor navigieren",
+      "zh": "转到编辑器"
     },
     "okay_button": {
       "en": "Okay",
-      "de": "OK"
+      "de": "OK",
+      "zh": "好"
     },
     "no_button": {
       "en": "No",
-      "de": "Nein"
+      "de": "Nein",
+      "zh": "否"
     },
     "yes_button": {
       "en": "Yes",
-      "de": "Ja"
+      "de": "Ja",
+      "zh": "是"
     },
     "published": {
       "en": "published",
-      "de": "veröffentlicht"
+      "de": "veröffentlicht",
+      "zh": "已发布"
     },
     "draft": {
       "en": "draft",
-      "de": "Entwurf"
+      "de": "Entwurf",
+      "zh": "草稿"
     },
     "updated": {
       "en": "updated",
-      "de": "Bearbeitet"
+      "de": "Bearbeitet",
+      "zh": "已更新"
     },
     "archived": {
       "en": "archived",
-      "de": "Archiviert"
+      "de": "Archiviert",
+      "zh": "已存档"
     },
     "publish_button": {
       "en": "Publish",
-      "de": "Veröffentlichen"
+      "de": "Veröffentlichen",
+      "zh": "发布"
     },
     "publish_tooltip": {
       "en": "Publish",
-      "de": "Veröffentlichen"
+      "de": "Veröffentlichen",
+      "zh": "发布"
     },
     "priority_label": {
       "en": "Priority",
-      "de": "Priorität"
+      "de": "Priorität",
+      "zh": "优先级"
     },
     "retry_button": {
       "en": "Retry",
-      "de": "Erneut versuchen"
+      "de": "Erneut versuchen",
+      "zh": "重试"
     },
     "save": {
       "en": "Save",
-      "de": "Speichern"
+      "de": "Speichern",
+      "zh": "保存"
     },
     "search_placeholder": {
       "en": "Search",
-      "de": "Suche"
+      "de": "Suche",
+      "zh": "搜索"
     },
     "searching": {
       "en": "Searching: '{{ term }}'",
-      "de": "Suche: '{{ term }}'"
+      "de": "Suche: '{{ term }}'",
+      "zh": "搜索： '{{ term }}'"
     },
     "select_all_label": {
       "en": "Select all",
-      "de": "Alle auswählen"
+      "de": "Alle auswählen",
+      "zh": "全选"
     },
     "select_channel": {
       "en": "Select channel",
-      "de": "Channel auswählen"
+      "de": "Channel auswählen",
+      "zh": "选择途径"
     },
     "sort_asc": {
       "en": "ASC",
-      "de": "aufsteigend"
+      "de": "aufsteigend",
+      "zh": "升序"
     },
     "sort_desc": {
       "en": "DESC",
-      "de": "absteigend"
+      "de": "absteigend",
+      "zh": "降序"
     },
     "sort_cdate": {
       "en": "Date created",
-      "de": "Erstellt am"
+      "de": "Erstellt am",
+      "zh": "创建日期"
     },
     "sort_deletedate": {
       "en": "Date deleted",
-      "de": "Gelösched am"
+      "de": "Gelösched am",
+      "zh": "删除日期"
     },
     "sort_edate": {
       "en": "Date edited",
-      "de": "Bearbeitet am"
+      "de": "Bearbeitet am",
+      "zh": "编辑日期"
     },
     "sort_filename": {
       "en": "File name",
-      "de": "Dateiname"
+      "de": "Dateiname",
+      "zh": "文件名"
     },
     "sort_filesize": {
       "en": "File size",
-      "de": "Dateigröße"
+      "de": "Dateigröße",
+      "zh": "文件大小"
     },
     "sort_name": {
       "en": "Name",
-      "de": "Name"
+      "de": "Name",
+      "zh": "名称"
     },
     "sort_pdate": {
       "en": "Date published",
-      "de": "Publiziert am"
+      "de": "Publiziert am",
+      "zh": "发布日期"
     },
     "sort_priority": {
       "en": "Priority",
-      "de": "Priorität"
+      "de": "Priorität",
+      "zh": "优先级"
     },
     "sort_template": {
       "en": "Template",
-      "de": "Vorlage"
+      "de": "Vorlage",
+      "zh": "模板"
     },
     "sort_type": {
       "en": "File type",
-      "de": "Dateityp"
+      "de": "Dateityp",
+      "zh": "文件类型"
     },
     "status_edited": {
       "en": "Edited",
-      "de": "Bearbeitet"
+      "de": "Bearbeitet",
+      "zh": "已编辑"
     },
     "status_published": {
       "en": "Published",
-      "de": "Veröffentlicht"
+      "de": "Veröffentlicht",
+      "zh": "已发布"
     },
     "status_publishat": {
       "en": "Planned",
-      "de": "Geplant"
+      "de": "Geplant",
+      "zh": "已计划发布"
     },
     "status_offline": {
       "en": "Offline",
-      "de": "Unveröffentlicht"
+      "de": "Unveröffentlicht",
+      "zh": "离线"
     },
     "status_queue": {
       "en": "Queued",
-      "de": "In Warteschlange"
+      "de": "In Warteschlange",
+      "zh": "队列"
     },
     "status_timeframe": {
       "en": "Not in time frame",
-      "de": "Außerhalb Zeitrahmen"
+      "de": "Außerhalb Zeitrahmen",
+      "zh": "不在时间范围内"
     },
     "template_label": {
       "en": "Template",
-      "de": "Vorlage"
+      "de": "Vorlage",
+      "zh": "模板"
     },
     "type_contenttag": {
       "en": "content tag",
-      "de": "Seitentag"
+      "de": "Seitentag",
+      "zh": "内容标签"
     },
     "type_contenttags": {
       "en": "content tags",
-      "de": "Seitentags"
+      "de": "Seitentags",
+      "zh": "内容标签"
     },
     "type_folder": {
       "en": "folder",
-      "de": "Ordner"
+      "de": "Ordner",
+      "zh": "文件夹"
     },
     "type_folders": {
       "en": "folders",
-      "de": "Ordner"
+      "de": "Ordner",
+      "zh": "文件夹"
     },
     "type_page": {
       "en": "page",
-      "de": "Seite"
+      "de": "Seite",
+      "zh": "页面"
     },
     "type_pages": {
       "en": "pages",
-      "de": "Seiten"
+      "de": "Seiten",
+      "zh": "页面"
     },
     "type_file": {
       "en": "file",
-      "de": "Datei"
+      "de": "Datei",
+      "zh": "文件"
     },
     "type_files": {
       "en": "files",
-      "de": "Dateien"
+      "de": "Dateien",
+      "zh": "文件"
     },
     "type_image": {
       "en": "image",
-      "de": "Bild"
+      "de": "Bild",
+      "zh": "图片"
     },
     "type_images": {
       "en": "images",
-      "de": "Bilder"
+      "de": "Bilder",
+      "zh": "图片"
     },
     "type_object": {
       "en": "object",
-      "de": "Objekt"
+      "de": "Objekt",
+      "zh": "对象"
     },
     "type_objects": {
       "en": "objects",
-      "de": "Objekte"
+      "de": "Objekte",
+      "zh": "对象"
     },
     "type_tag": {
       "en": "tag",
-      "de": "Tag"
+      "de": "Tag",
+      "zh": "标签"
     },
     "type_tags": {
       "en": "tags",
-      "de": "Tags"
+      "de": "Tags",
+      "zh": "标签"
     },
     "type_template": {
       "en": "template",
-      "de": "Vorlage"
+      "de": "Vorlage",
+      "zh": "模板"
     },
     "type_templates": {
       "en": "templates",
-      "de": "Vorlagen"
+      "de": "Vorlagen",
+      "zh": "模板"
     },
     "type_templatetag": {
       "en": "template tag",
-      "de": "Vorlagentag"
+      "de": "Vorlagentag",
+      "zh": "模板标签"
     },
     "type_templatetags": {
       "en": "template tags",
-      "de": "Vorlagentags"
+      "de": "Vorlagentags",
+      "zh": "模板标签"
     },
     "type_variant": {
       "en": "variant",
-      "de": "Variante"
+      "de": "Variante",
+      "zh": "变体"
     },
     "type_variants": {
       "en": "variants",
-      "de": "Varianten"
+      "de": "Varianten",
+      "zh": "变体"
     },
     "type_node": {
       "en": "node",
-      "de": "Node"
+      "de": "Node",
+      "zh": "节点"
     },
     "type_nodes": {
       "en": "nodes",
-      "de": "Nodes"
+      "de": "Nodes",
+      "zh": "节点"
     },
     "undo_button": {
       "en": "Undo",
-      "de": "Rückgängig"
+      "de": "Rückgängig",
+      "zh": "撤消"
     },
     "usage_label": {
       "en": "Usage",
-      "de": "Verwendung"
+      "de": "Verwendung",
+      "zh": "用法"
     },
     "title_label": {
       "en": "Title",
-      "de": "Titel"
+      "de": "Titel",
+      "zh": "标题"
     },
     "project": {
       "en": "Project",
-      "de": "Projekt"
+      "de": "Projekt",
+      "zh": "项目"
     },
     "projects": {
       "en": "Projects",
-      "de": "Projekte"
+      "de": "Projekte",
+      "zh": "项目"
     },
     "user": {
       "en": "User",
-      "de": "Benutzer"
+      "de": "Benutzer",
+      "zh": "用户"
     },
     "users": {
       "en": "Users",
-      "de": "Benutzer"
+      "de": "Benutzer",
+      "zh": "用户"
     },
     "permission": {
       "en": "Permission",
-      "de": "Berechtigung"
+      "de": "Berechtigung",
+      "zh": "权限"
     },
     "permissions": {
       "en": "Permissions",
-      "de": "Berechtigungen"
+      "de": "Berechtigungen",
+      "zh": "权限"
     },
     "schema": {
       "en": "Schema",
-      "de": "Schema"
+      "de": "Schema",
+      "zh": "数据模型"
     },
     "schemas": {
       "en": "Schemas",
-      "de": "Schemas"
+      "de": "Schemas",
+      "zh": "数据模型"
     },
     "microschema": {
       "en": "Microschema",
-      "de": "Microschema"
+      "de": "Microschema",
+      "zh": "内嵌数据模型"
     },
     "microschemas": {
       "en": "Microschemas",
-      "de": "Microschemas"
+      "de": "Microschemas",
+      "zh": "内嵌数据模型"
     },
     "groups": {
       "en": "Groups",
-      "de": "Gruppen"
+      "de": "Gruppen",
+      "zh": "用户组"
     },
     "roles": {
       "en": "Roles",
-      "de": "Rollen"
+      "de": "Rollen",
+      "zh": "角色"
     },
     "field_required": {
       "en": "This field is required",
-      "de": "Dieses Feld is erforderlich"
+      "de": "Dieses Feld is erforderlich",
+      "zh": "此字段为必填"
     }
 }

--- a/src/app/core/providers/i18n/translations_json/editor.translations.json
+++ b/src/app/core/providers/i18n/translations_json/editor.translations.json
@@ -1,142 +1,177 @@
 {
     "add_tag": {
       "en": "Add tag",
-      "de": "Tag hinzufügen"
+      "de": "Tag hinzufügen",
+      "zh": "添加标签"
     },
     "binary_info": {
       "en": "File info",
-      "de": "Datei-Info"
+      "de": "Datei-Info",
+      "zh": "文件信息"
     },
     "create_node": {
       "en": "Create node",
-      "de": "Node erstellen"
+      "de": "Node erstellen",
+      "zh": "创建节点"
     },
     "create_new_tag": {
-        "en": "Create new tag",
-        "de": "Neuen Tag erstellen"
+      "en": "Create new tag",
+      "de": "Neuen Tag erstellen",
+      "zh": "创建新标签"
     },
     "edit_image": {
       "en": "Edit image",
-      "de": "Bild bearbeiten"
+      "de": "Bild bearbeiten",
+      "zh": "编辑图像"
     },
     "error_max_value": {
       "en": "The value is greater than the maximum",
-      "de": "Der Wert is größer als Maximum"
+      "de": "Der Wert is größer als Maximum",
+      "zh": "该值大于最大值"
     },
     "error_min_value": {
       "en": "The value is below the minimum",
-      "de": "Der Wert is weniger als Minimum"
+      "de": "Der Wert is weniger als Minimum",
+      "zh": "该值低于最小值"
     },
     "error_required": {
       "en": "This field is required",
-      "de": "Dieses Feld is erforderlich"
+      "de": "Dieses Feld is erforderlich",
+      "zh": "此字段为必填"
     },
     "error_number": {
       "en": "This field must be a valid number",
-      "de": "Dieses Feld muss eine gültige Zahl sein"
+      "de": "Dieses Feld muss eine gültige Zahl sein",
+      "zh": "此字段必须为有效数字"
     },
     "language_switch_to": {
       "en": "Switch to {{language}}",
-      "de": "Auf {{language}} umschalten"
+      "de": "Auf {{language}} umschalten",
+      "zh": "切换至 {{language}}"
     },
     "language_translate_to": {
       "en": "Create {{language}} version",
-      "de": "{{language}} Variante erstellen"
+      "de": "{{language}} Variante erstellen",
+      "zh": "创建 {{language}} 版本"
     },
     "node_already_unpublished": {
       "en": "The node is already unpublished",
-      "de": "Der Node ist bereits depubliziert"
+      "de": "Der Node ist bereits depubliziert",
+      "zh": "该节点已经是未发布状态"
     },
     "node_published": {
       "en": "Node successfully published",
-      "de": "Node erfolgreich veröffentlicht"
+      "de": "Node erfolgreich veröffentlicht",
+      "zh": "节点发布成功"
     },
     "node_language_published": {
       "en": "Node successfully published as version {{version}}",
-      "de": "Node erfolgreich veröffentlicht als Version {{version}}"
+      "de": "Node erfolgreich veröffentlicht als Version {{version}}",
+      "zh": "节点已成功发布为版本{{version}}"
     },
     "node_publish_error": {
       "en": "Node could not be published",
-      "de": "Node könnte nicht veröffentlicht werden"
+      "de": "Node könnte nicht veröffentlicht werden",
+      "zh": "节点无法发布"
     },
     "node_saved": {
       "en": "Node successfully saved",
-      "de": "Node erfolgreich gespeichert"
+      "de": "Node erfolgreich gespeichert",
+      "zh": "节点保存成功"
     },
     "node_save_error": {
       "en": "Node could not be saved",
-      "de": "Node könnte nicht gespeichert werden"
+      "de": "Node könnte nicht gespeichert werden",
+      "zh": "无法保存节点"
     },
     "node_unpublished": {
       "en": "Node unpublished successfully",
-      "de": "Node erfolgreich depubliziert"
+      "de": "Node erfolgreich depubliziert",
+      "zh": "节点已成功更改为未发布状态"
     },
     "publish_all": {
       "en": "Publish all languages",
-      "de": "Alle Sprachen veröffentlichen"
+      "de": "Alle Sprachen veröffentlichen",
+      "zh": "发布所有语言"
     },
     "publish_button": {
       "en": "Publish",
-      "de": "Veröffentlichen"
+      "de": "Veröffentlichen",
+      "zh": "发布"
     },
     "preview_button": {
       "en": "Preview",
-      "de": "Vorschau"
+      "de": "Vorschau",
+      "zh": "预览"
     },
     "remove_list_item_tooltip": {
       "en": "Drop here to remove",
-      "de": "Zum Entfernen hier ablegen"
+      "de": "Zum Entfernen hier ablegen",
+      "zh": "拖放到此处以删除"
     },
     "replace_file": {
       "en": "Replace file",
-      "de": "Datei ersetzen"
+      "de": "Datei ersetzen",
+      "zh": "替换文件"
     },
     "remove_file": {
       "en": "Remove file",
-      "de": "Datei entfernen"
+      "de": "Datei entfernen",
+      "zh": "删除文件"
     },
     "save_button": {
       "en": "Save",
-      "de": "Speichern"
+      "de": "Speichern",
+      "zh": "保存"
     },
     "select_file": {
       "en": "Select file",
-      "de": "Datei auswählen"
+      "de": "Datei auswählen",
+      "zh": "选择文件"
     },
     "select_node": {
       "en": "Select node",
-      "de": "Node auswählen"
+      "de": "Node auswählen",
+      "zh": "选择节点"
     },
     "tag_name": {
       "en": "Tag name",
-      "de": "Tag hinzufügen"
+      "de": "Tag hinzufügen",
+      "zh": "标签名称"
     },
     "unpublish": {
       "en": "Unpublish",
-      "de": "Depublizieren"
+      "de": "Depublizieren",
+      "zh": "取消发布"
     },
     "unpublish_all": {
       "en": "Unpublish all languages",
-      "de": "Alle Sprachen depublizieren"
+      "de": "Alle Sprachen depublizieren",
+      "zh": "取消发布所有语言"
     },
     "no_projects": {
       "en": "No projects to display.",
-      "de": "Es existieren keine Projekte."
+      "de": "Es existieren keine Projekte.",
+      "zh": "没有要显示的项目。"
     },
     "create_new_project": {
       "en": "Create a new project",
-      "de": "Neues Projekt erstellen"
+      "de": "Neues Projekt erstellen",
+      "zh": "创建一个新项目"
     },
     "server_error": {
       "en": "An error occured during server communication. Please repeat your action or get back to the software maintainer.",
-      "de": "Bei der Kommunikation mit dem Server ist ein Fehler aufgetreten. Bitte Vorgang wiederholen oder Hersteller kontaktieren."
+      "de": "Bei der Kommunikation mit dem Server ist ein Fehler aufgetreten. Bitte Vorgang wiederholen oder Hersteller kontaktieren.",
+      "zh": "服务器通信期间发生错误。请重复你的操作或求助系统管理员。"
     },
     "path_copied": {
       "en": "Path copied to clipboard",
-      "de": "Pfad in die Zwischenablage kopiert"
+      "de": "Pfad in die Zwischenablage kopiert",
+      "zh": "路径已复制到剪贴板"
     },
     "path_copy_failed": {
       "en": "No webroot path for this node found",
-      "de": "Keinen Webroot-Pfad für diesen Node gefunden"
+      "de": "Keinen Webroot-Pfad für diesen Node gefunden",
+      "zh": "找不到此节点的webroot路径"
     }
   }

--- a/src/app/core/providers/i18n/translations_json/lang.translations.json
+++ b/src/app/core/providers/i18n/translations_json/lang.translations.json
@@ -1,10 +1,17 @@
 {
     "de": {
       "en": "German",
-      "de": "Deutsch"
+      "de": "Deutsch",
+      "zh": "德语"
     },
     "en": {
       "en": "English",
-      "de": "Englisch"
+      "de": "Englisch",
+      "zh": "英语"
+    },
+    "zh": {
+      "en": "Chinese",
+      "de": "Chinesisch",
+      "zh": "中文"
     }
   }

--- a/src/app/core/providers/i18n/translations_json/list.translations.json
+++ b/src/app/core/providers/i18n/translations_json/list.translations.json
@@ -1,58 +1,72 @@
 {
     "copy": {
         "en": "Copy",
-        "de": "Kopieren"
+        "de": "Kopieren",
+        "zh": "复制"
     },
     "copy_success": {
         "en": "Node copied successfully",
-        "de": "Node erfolgreich kopiert"
+        "de": "Node erfolgreich kopiert",
+        "zh": "节点复制成功"
     },
     "copy_error": {
         "en": "Copying node failed\n{{error}}",
-        "de": "Kopieren des Nodes fehlgeschlagen\n{{error}}"
+        "de": "Kopieren des Nodes fehlgeschlagen\n{{error}}",
+        "zh": "复制节点失败\n{{error}}"
     },
     "language_select_switch_to": {
         "en": "Display nodes in {{language}}",
-        "de": "Nodes in {{language}} zeigen"
+        "de": "Nodes in {{language}} zeigen",
+        "zh": "显示 {{language}} 节点"
     },
     "move": {
         "en": "Move",
-        "de": "Verschieben"
+        "de": "Verschieben",
+        "zh": "移动"
     },
     "move_success": {
         "en": "Node moved successfully",
-        "de": "Node erfolgreich verschoben"
+        "de": "Node erfolgreich verschoben",
+        "zh": "节点移动成功"
     },
     "move_error": {
         "en": "Moving node failed\n{{error}}",
-        "de": "Verschieben des Nodes fehlgeschlagen\n{{error}}"
+        "de": "Verschieben des Nodes fehlgeschlagen\n{{error}}",
+        "zh": "移动节点失败\n{{error}}"
     },
     "folder_dialog_title": {
         "en": "Choose destination container",
-        "de": "Zielcontainer wählen"
+        "de": "Zielcontainer wählen",
+        "zh": "选择目标容器"
     },
     "delete": {
         "en": "Delete",
-        "de": "Löschen"
+        "de": "Löschen",
+        "zh": "删除"
     },
     "edit": {
         "en": "Edit",
-        "de": "Bearbeiten"
+        "de": "Bearbeiten",
+        "zh": "编辑"
     },
     "no_results": {
         "en": "No results",
-        "de": "Keine Ergebnisse"
+        "de": "Keine Ergebnisse",
+        "zh": "没有找到结果"
     },
     "search_error_occured": {
         "en": "An error has occurred while performing search",
-        "de": "Ein Fehler ist aufgetreten"
+        "de": "Ein Fehler ist aufgetreten",
+        "zh": "执行搜索时发生错误"
     },
     "upload_files": {
         "en": "Upload files",
-        "de": "Dateien hochladen"
+        "de": "Dateien hochladen",
+        "zh": "上传文件"
     },
     "choose_files": {
         "en": "Select or drop files...",
-        "de": "Dateien auswählen oder hier ablegen..."
+        "de": "Dateien auswählen oder hier ablegen...",
+        "zh": "选择或拖放文件到此处..."
     }
 }

--- a/src/app/core/providers/i18n/translations_json/modal.translations.json
+++ b/src/app/core/providers/i18n/translations_json/modal.translations.json
@@ -1,154 +1,192 @@
 {
     "added_tags": {
         "en": "Added tags",
-        "de": "Tags hinzugefügt"
+        "de": "Tags hinzugefügt",
+        "zh": "添加的标签"
     },
     "additional_changes_label": {
         "en": "+ {{count}} additional changes",
-        "de": "+ {{count}} weitere Änderungen"
+        "de": "+ {{count}} weitere Änderungen",
+        "zh": "+ {{count}} 个其他更改"
     },
     "apply_edits": {
         "en": "Apply edits",
-        "de": "Änderungen übernehmen"
+        "de": "Änderungen übernehmen",
+        "zh": "应用修改"
     },
     "change_password_title": {
         "en": "Change Password",
-        "de": "Passwort ändern"
+        "de": "Passwort ändern",
+        "zh": "更改密码"
     },
     "change_password_button": {
         "en": "Change password",
-        "de": "Passwort ändern"
+        "de": "Passwort ändern",
+        "zh": "更改密码"
     },
     "change_password_success": {
         "en": "Password changed successfully",
-        "de": "Passwort erfolgreich geändert"
+        "de": "Passwort erfolgreich geändert",
+        "zh": "密码更改成功"
     },
     "confirm_navigation_body": {
         "en": "Unsaved changes will be lost.",
-        "de": "Ungespeicherte Änderungen gehen verloren."
+        "de": "Ungespeicherte Änderungen gehen verloren.",
+        "zh": "未保存的更改将丢失。"
     },
     "confirm_navigation_title": {
         "en": "Discard changes?",
-        "de": "Änderungen verwerfen?"
+        "de": "Änderungen verwerfen?",
+        "zh": "放弃更改？"
     },
     "confirm_password_label": {
         "en": "Confirm password",
-        "de": "Passwort bestätigen"
+        "de": "Passwort bestätigen",
+        "zh": "确认密码"
     },
     "create_project_button": {
         "en": "Create Project",
-        "de": "Projekt erstellen"
+        "de": "Projekt erstellen",
+        "zh": "创建项目"
     },
     "create_project_conflict": {
         "en": "A project with this name already exists. Please choose another name.",
-        "de": "Es existiert bereits ein Projekt mit diesem Namen. Bitte wählen Sie einen anderen Namen."
+        "de": "Es existiert bereits ein Projekt mit diesem Namen. Bitte wählen Sie einen anderen Namen.",
+        "zh": "已经存在此名称的项目。请选择其他名称。"
     },
     "create_project_non_container_hint": {
         "en": "The chosen schema is not a container. You will not be able to create other nodes in this project.",
-        "de": "Das gewählte Schema is kein Container. Sie werden in diesem Projekt keine anderen Nodes erstellen können."
+        "de": "Das gewählte Schema is kein Container. Sie werden in diesem Projekt keine anderen Nodes erstellen können.",
+        "zh": "所选数据模型不是容器。你将无法在该项目中创建其他数据节点。"
     },
     "create_project_schema_label": {
         "en": "Schema for root node",
-        "de": "Schema für Root-Node"
+        "de": "Schema für Root-Node",
+        "zh": "根节点的数据模型"
     },
     "create_project_title": {
         "en": "New Project",
-        "de": "Neues Projekt"
+        "de": "Neues Projekt",
+        "zh": "新项目"
     },
     "create_project_anonymous_access": {
         "en": "Allow anonymous users to read contents",
-        "de": "Erlaube anonymen Benutzern Inhalte zu lesen"
+        "de": "Erlaube anonymen Benutzern Inhalte zu lesen",
+        "zh": "允许匿名用户读取数据内容"
     },
     "delete_project_title": {
         "en": "Delete Project",
-        "de": "Projekt löschen"
+        "de": "Projekt löschen",
+        "zh": "删除项目"
     },
     "delete_project_body": {
         "en": "Are you sure you want to delete project <strong>\"{{ name }}\"</strong>?",
-        "de": "Sind Sie sicher, dass sie Projekt <strong>\"{{ name }}\"</strong> löschen wollen?"
+        "de": "Sind Sie sicher, dass sie Projekt <strong>\"{{ name }}\"</strong> löschen wollen?",
+        "zh": "你确定要删除项目 <strong>\"{{ name }}\"</strong> 吗？"
     },
     "delete_node_title": {
         "en": "Delete node",
-        "de": "Node löschen"
+        "de": "Node löschen",
+        "zh": "删除节点"
     },
     "delete_node_body": {
         "en": "Are you sure you want to delete this node <strong>\"{{ name }}\"</strong>?",
-        "de": "Sind Sie sicher, dass sie die Node <strong>\"{{ name }}\"</strong> löschen wollen?"
+        "de": "Sind Sie sicher, dass sie die Node <strong>\"{{ name }}\"</strong> löschen wollen?",
+        "zh": "你确定要删除这个节点 <strong>\"{{ name }}\"</strong> 吗？"
     },
     "discard_changes_button": {
         "en": "Discard changes",
-        "de": "Änderungen verwerfen"
+        "de": "Änderungen verwerfen",
+        "zh": "放弃更改"
     },
     "edit_image_title": {
         "en": "Edit Image",
-        "de": "Bild bearbeiten"
+        "de": "Bild bearbeiten",
+        "zh": "编辑图像"
     },
     "image_edited_label": {
         "en": "image edited",
-        "de": "Bild bearbeitet"
+        "de": "Bild bearbeitet",
+        "zh": "图像已编辑"
     },
     "list_changed_label": {
         "en": "list changed",
-        "de": "Liste geändert"
+        "de": "Liste geändert",
+        "zh": "列表已更改"
     },
     "new_file_selected_label": {
         "en": "new file selected",
-        "de": "Neue Datei ausgewählt"
+        "de": "Neue Datei ausgewählt",
+        "zh": "已选择新文件"
     },
     "new_password_label": {
         "en": "New password",
-        "de": "Neues Passwort"
+        "de": "Neues Passwort",
+        "zh": "新密码"
     },
     "removed_tags": {
         "en": "Removed tags",
-        "de": "Tags gelöscht"
+        "de": "Tags gelöscht",
+        "zh": "已移除标签"
     },
     "save_and_close_button": {
         "en": "Save and close",
-        "de": "Speichern und schließen"
+        "de": "Speichern und schließen",
+        "zh": "保存并关闭"
     },
     "uploading_file": {
         "en": "Uploading file…",
-        "de": "Lade Datei hoch …"
+        "de": "Lade Datei hoch …",
+        "zh": "正在上传文件…"
     },
     "uploading_files": {
         "en": "Uploading files…",
-        "de": "Lade Dateien hoch …"
+        "de": "Lade Dateien hoch …",
+        "zh": "正在上传文件…"
     },
     "node_conflict": {
         "en": "Resolve conflicts",
-        "de": "Änderungskonflikte beheben"
+        "de": "Änderungskonflikte beheben",
+        "zh": "解决冲突"
     },
     "node_conflict_description": {
         "en": "Your changes conflict with the saved version on the server.",
-        "de": "Ihre Änderungen würden Änderungen am Server überschreiben."
+        "de": "Ihre Änderungen würden Änderungen am Server überschreiben.",
+        "zh": "你的更改与服务器上保存的版本冲突。"
     },
     "theirs_version": {
         "en": "Changes on the server",
-        "de": "Änderungen am Server"
+        "de": "Änderungen am Server",
+        "zh": "服务器上的更改"
     },
     "my_version": {
         "en": "Your changes",
-        "de": "Ihre Änderungen"
+        "de": "Ihre Änderungen",
+        "zh": "你的更改"
     },
     "save_changes": {
         "en": "Save changes",
-        "de": "Änderungen übernehmen"
+        "de": "Änderungen übernehmen",
+        "zh": "保存更改"
     },
     "use_this_version": {
         "en": "Apply",
-        "de": "Übernehmen"
+        "de": "Übernehmen",
+        "zh": "应用"
     },
     "no_preview_available": {
         "en": "No Preview Available",
-        "de": "Keine Vorschau verfügbar"
+        "de": "Keine Vorschau verfügbar",
+        "zh": "没有预览可用"
     },
     "file_too_large": {
         "en": "File too large",
-        "de": "Zu große Datei"
+        "de": "Zu große Datei",
+        "zh": "文件太大"
     },
     "file_too_large_body": {
         "en": "The file <code>{{ fileName }}</code> is too large to upload. Please choose a smaller file or <a target=\"_blank\" href=\"https://getmesh.io/docs/administration-guide/#_upload_options\">change the upload limit in the configuration</a>.",
-        "de": "Die Datei <code>{{ fileName }}</code> ist zu groß zum Hochladen. Bitte wählen Sie eine kleinere Datei, oder <a target=\"_blank\" href=\"https://getmesh.io/docs/administration-guide/#_upload_options\">ändern Sie das Upload-Limit in der Konfiguration</a>."
+        "de": "Die Datei <code>{{ fileName }}</code> ist zu groß zum Hochladen. Bitte wählen Sie eine kleinere Datei, oder <a target=\"_blank\" href=\"https://getmesh.io/docs/administration-guide/#_upload_options\">ändern Sie das Upload-Limit in der Konfiguration</a>.",
+        "zh": "上传的文件 <code>{{ fileName }}</code> 太大。请选择一个较小的文件，或<a target=\"_blank\" href=\"https://getmesh.io/docs/administration-guide/#_upload_options\">更改配置中的上传限制</a>。"
     }
 }

--- a/src/app/core/providers/i18n/translations_json/nodebrowser.translations.json
+++ b/src/app/core/providers/i18n/translations_json/nodebrowser.translations.json
@@ -1,6 +1,7 @@
 {
   "no_children_found": {
     "en": "No children found",
-    "de": "Keine Unterelemente gefunden"
+    "de": "Keine Unterelemente gefunden",
+    "zh": "未找到子集"
   }
 }

--- a/src/app/shared/components/node-status/node-status.component.ts
+++ b/src/app/shared/components/node-status/node-status.component.ts
@@ -65,6 +65,10 @@ export class NodeStatusComponent implements OnChanges, OnDestroy {
         de: {
             date: 'dd.MM.yyyy',
             time: 'HH:mm:ss'
+        },
+        zh: {
+            date: 'yyyy-MM-dd',
+            time: 'HH:mm:ss'
         }
     };
 

--- a/src/assets/config/mesh-ui-config.js
+++ b/src/assets/config/mesh-ui-config.js
@@ -4,9 +4,9 @@ window.MeshUiConfig = {
     /** The ISO-639-1 code of the default language */
     defaultLanguage: 'en',
     /** The ISO-639-1 codes of the available languages for the frontend app */
-    uiLanguages: ['en', 'de'],
+    uiLanguages: ['en', 'de', 'zh'],
     /** The ISO-639-1 codes of the available languages for Mesh */
-    contentLanguages: ['en', 'de'],
+    contentLanguages: ['en', 'de', 'zh'],
     /** The ISO-639-1 code of the language to be used in case a requested ressource is not available in the requested langauge */
     fallbackLanguage: 'en',
     /** This is the credential username for a ressource requested without authentication */


### PR DESCRIPTION
Hello there,

First of all, thank you very much for sharing such a great project. Really very good.

Recently, I tried to add a Chinese (Simplified Chinese) version to the mesh and mesh-ui i18n. I also tried to share it. If anyone needs it, I hope this will bring you some help.

There are some instructions:
1, based on the git version of 2019-11-09;
2, each i18n property has been translated, no missing one;
3, I have personally checked each one, and probably there should be no problem other than the individual translation (such as "segment field").
4, of course, if you make some adjustments during the use process, there is no problem.
5, I tried to automatically match the user's display language in mesh-ui, but did not succeed. (I added a similar code to i18n.service.spec.ts, but it is still en by default on the page)

I have tested it locally, and here you can see a display effect diagram:

![Firefox-Screenshot-2019-11-09-T09-26-02-493-Z](https://user-images.githubusercontent.com/10892032/68529174-bc455880-0336-11ea-89bb-27bfafcfb973.png)

