### PR TITLE
Fix two Portuguese translations having wrong lang key

### DIFF
--- a/src/app/core/providers/i18n/translations_json/admin.translations.json
+++ b/src/app/core/providers/i18n/translations_json/admin.translations.json
@@ -21,13 +21,13 @@
         "en": "Assign to role",
         "de": "Zu Rolle zuweisen",
         "zh": "分配给角色",
-        "en": "Atribuir a papel"
+        "pt": "Atribuir a papel"
     },
     "all": {
         "en": "all",
         "de": "alle",
         "zh": "全部",
-        "en": "todos"
+        "pt": "todos"
     },
     "all_groups": {
         "en": "All groups",


### PR DESCRIPTION
In the English mesh UI under permissions it shows "todos" in the last column. I was wondering what that means. Turns out it has nothing to do with "to-dos", it's just Portuguese for "all" :). There are two Portuguese translations with `"en"` instead of `"pt"` as key, overriding the English labels.