### PR TITLE
Ms/default content lang

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -52,7 +52,6 @@ export class AppModule {
         authEffects: AuthEffectsService,
         searchEffects: SearchEffectsService
     ) {
-        i18nService.setLanguage('en');
         authEffects.validateSession();
         searchEffects.checkSearchAvailability();
         // router.events.subscribe(event => console.log(event));

--- a/src/app/common/models/appconfig.model.ts
+++ b/src/app/common/models/appconfig.model.ts
@@ -9,6 +9,8 @@ export interface MeshUiAppConfig {
     readonly defaultLanguage: string;
     /** The ISO-639-1 codes of the available languages for the frontend app */
     readonly uiLanguages: string[];
+    /** The ISO-639-1 code of the default language for Mesh */
+    readonly defaultContentLanguage: string;
     /** The ISO-639-1 codes of the available languages for Mesh */
     readonly contentLanguages: string[];
     /** The ISO-639-1 code of the language to be used in case a requested ressource is not available in the requested langauge */

--- a/src/app/core/providers/config/config.service.mock.ts
+++ b/src/app/core/providers/config/config.service.mock.ts
@@ -7,6 +7,7 @@ export class MockConfigService implements ConfigService {
     readonly ANONYMOUS_USER_NAME = 'anonymous';
     readonly UI_LANGUAGES = ['en', 'de'];
     FALLBACK_LANGUAGE = 'en';
+    DEFAULT_CONTENT_LANGUAGE = 'en';
     CONTENT_LANGUAGES = ['en', 'de'];
     readonly CONTENT_ITEMS_PER_PAGE = 8;
     getPreviewUrlsByProjectName(projectName: string) {

--- a/src/app/core/providers/config/config.service.ts
+++ b/src/app/core/providers/config/config.service.ts
@@ -32,6 +32,9 @@ export class ConfigService {
         return this.getConfigValueFromProperty('uiLanguages') as string[];
     }
 
+    get DEFAULT_CONTENT_LANGUAGE(): string {
+        return this.getConfigValueFromProperty('defaultContentLanguage', 'en') as string;
+    }
     /**
      * Languages in which the content is available.
      * TODO: This will need to be user-configurable eventually.
@@ -67,7 +70,10 @@ export class ConfigService {
      * @param property key of config object
      * @param fallbackValue key of config object
      */
-    getConfigValueFromProperty<K extends keyof MeshUiAppConfig>(property: K, fallbackValue?: MeshUiAppConfig[K]): MeshUiAppConfig[K] {
+    getConfigValueFromProperty<K extends keyof MeshUiAppConfig>(
+        property: K,
+        fallbackValue?: MeshUiAppConfig[K]
+    ): MeshUiAppConfig[K] {
         const retVal = this.appConfig[property];
         if (retVal) {
             return retVal;

--- a/src/app/core/providers/i18n/i18n.service.spec.ts
+++ b/src/app/core/providers/i18n/i18n.service.spec.ts
@@ -126,4 +126,5 @@ class MockTranslateService {
         return `${key}_translated`;
     });
     setDefaultLang = jasmine.createSpy('setDefaultLang');
+    use = jasmine.createSpy('use');
 }

--- a/src/app/core/providers/i18n/i18n.service.ts
+++ b/src/app/core/providers/i18n/i18n.service.ts
@@ -8,6 +8,7 @@ export type UILanguage = 'en' | 'de' | 'zh' | 'pt' | 'hu';
 @Injectable()
 export class I18nService {
     constructor(private ngxTranslate: TranslateService, private config: ConfigService) {
+        ngxTranslate.use(config.DEFAULT_CONTENT_LANGUAGE);
         ngxTranslate.setDefaultLang(config.FALLBACK_LANGUAGE);
     }
 

--- a/src/app/state/providers/application-state.service.ts
+++ b/src/app/state/providers/application-state.service.ts
@@ -61,7 +61,7 @@ export class ApplicationStateService {
             entity: new EntityStateActions(),
             editor: new EditorStateActions(config),
             list: new ListStateActions(config),
-            ui: new UIStateActions(),
+            ui: new UIStateActions(config),
             tag: new TagsStateActions()
         });
 

--- a/src/app/state/providers/ui-state-actions.ts
+++ b/src/app/state/providers/ui-state-actions.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { CloneDepth, Immutable, StateActionBranch } from 'immutablets';
 
+import { ConfigService } from '../../core/providers/config/config.service';
 import { UILanguage } from '../../core/providers/i18n/i18n.service';
 import { AppState } from '../models/app-state.model';
 import { UIState } from '../models/ui-state.model';
@@ -11,12 +12,12 @@ export class UIStateActions extends StateActionBranch<AppState> {
     @CloneDepth(1)
     private ui: UIState;
 
-    constructor() {
+    constructor(config: ConfigService) {
         super({
             uses: ['ui'],
             initialState: {
                 ui: {
-                    currentLanguage: 'en',
+                    currentLanguage: config.DEFAULT_CONTENT_LANGUAGE as UILanguage,
                     searchAvailable: false
                 }
             }

--- a/src/assets/config/mesh-ui-config.js
+++ b/src/assets/config/mesh-ui-config.js
@@ -5,6 +5,8 @@ window.MeshUiConfig = {
     defaultLanguage: 'en',
     /** The ISO-639-1 codes of the available languages for the frontend app */
     uiLanguages: ['en', 'de', 'zh', 'pt', 'hu'],
+    /** The ISO-639-1 code of the default language for Mesh */
+    defaultContentLanguage: 'en',
     /** The ISO-639-1 codes of the available languages for Mesh */
     contentLanguages: ['en', 'de', 'zh', 'pt', 'hu'],
     /** The ISO-639-1 code of the language to be used in case a requested ressource is not available in the requested langauge */


### PR DESCRIPTION
### Default content lang configuration

Currently the content( i18n )-language is always set to English. This PR makes the content-language configurable, to allow other-languages as default-lang. The ideal solution would be to have the content-language user-configurable, but a config-option for a default-lang would be a quick win with little effort.

### Detailed description

- Adds a new configuration-fied `defaultContentLanguage`. 
- Exposes the field in the config-service. 
- Remove static-set of 'en' as i18n-language.
- Use config-field as initial value for i18n.
- Use config-field as initial value for the language-switcher.
