### PR TITLE
Make the boolean-field-component relative positioned

### DIFF
--- a/src/app/form-generator/components/boolean-field/boolean-field.scss
+++ b/src/app/form-generator/components/boolean-field/boolean-field.scss
@@ -2,6 +2,14 @@
 @import "../../common-styles";
 
 :host.mesh-field {
+    /*
+        position: relative is necessary to provide an anchor-element for the
+        absolute positioned checkbox-element from gtx-checkbox. Without this
+        there will be issues with overflows of static-positioned parent elements.
+        See: https://github.com/gentics/mesh-ui/issues/337
+     */
+    position: relative;
+
     display: flex;
     justify-content: space-between;
     padding-top: 10px;


### PR DESCRIPTION
This is necessary to provide an anchor for the gtx-checkbox.
The checkbox uses an absolute-positioned input-element.
If the parent element does not provide an anchor the
element is anchored to the nearest non-static positioned parent.
This can cause weird issues with overflows of elements.

This should resolve: https://github.com/gentics/mesh-ui/issues/337